### PR TITLE
Address some compiler warnings

### DIFF
--- a/include/xten/Dialect/XTen/XTenOpWrapper.h
+++ b/include/xten/Dialect/XTen/XTenOpWrapper.h
@@ -72,24 +72,24 @@ namespace xilinx {
         public:
             Conv2dOpWrapper(Conv2dOp c);
             ~Conv2dOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
         class PartialConv2dOpWrapper : public AbsOpWrapper {
@@ -98,24 +98,24 @@ namespace xilinx {
         public:
             PartialConv2dOpWrapper(PartialConv2dOp c);
             ~PartialConv2dOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
         class Conv2dReLUOpWrapper : public AbsOpWrapper {
@@ -124,24 +124,24 @@ namespace xilinx {
         public:
             Conv2dReLUOpWrapper(Conv2dReLUOp c);
             ~Conv2dReLUOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
         class PartialConv2dReLUOpWrapper : public AbsOpWrapper {
@@ -150,24 +150,24 @@ namespace xilinx {
         public:
             PartialConv2dReLUOpWrapper(PartialConv2dReLUOp c);
             ~PartialConv2dReLUOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
         class Conv2dBatchNormReLUOpWrapper : public AbsOpWrapper {
@@ -176,24 +176,24 @@ namespace xilinx {
         public:
             Conv2dBatchNormReLUOpWrapper(Conv2dBatchNormReLUOp c);
             ~Conv2dBatchNormReLUOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
         class PartialConv2dBatchNormReLUOpWrapper : public AbsOpWrapper {
@@ -202,24 +202,24 @@ namespace xilinx {
         public:
             PartialConv2dBatchNormReLUOpWrapper(PartialConv2dBatchNormReLUOp c);
             ~PartialConv2dBatchNormReLUOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
 
 
@@ -229,24 +229,24 @@ namespace xilinx {
         public:
             MaxPool2dOpWrapper(Torch::AtenMaxPool2dOp c);
             ~MaxPool2dOpWrapper();
-            Operation* getUnderlyingOperation();
-            Value getWeights();
-            Value getInput();
-            Value getPartialInput();
-            Optional<Value> getBiases();
-            ArrayRef<Value> getBN();
-            virtual unsigned int getF0();
-            virtual unsigned int getF1();
-            unsigned int getStride();
-            bool hasWeights();
-            bool hasBias();
-            bool hasBN();
-            bool isDepthWise();
-            double getKernelEfficiency();
+            Operation* getUnderlyingOperation() override;
+            Value getWeights() override;
+            Value getInput() override;
+            Value getPartialInput() override;
+            Optional<Value> getBiases() override;
+            ArrayRef<Value> getBN() override;
+            virtual unsigned int getF0() override;
+            virtual unsigned int getF1() override;
+            unsigned int getStride() override;
+            bool hasWeights() override;
+            bool hasBias() override;
+            bool hasBN() override;
+            bool isDepthWise() override;
+            double getKernelEfficiency() override;
             Operation* buildOp(OpBuilder &builder, TypeRange returnType, Value input, llvm::Optional<Value> weight,
                                llvm::Optional<Value> bias,llvm::Optional<Value> partialIn, bool firstInPartialChain,
-                               llvm::Optional<ArrayRef<Value>> bn);
-            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes);
+                               llvm::Optional<ArrayRef<Value>> bn) override;
+            Operation* wCopy(OpBuilder &builder, unsigned int into, llvm::Optional<TypeRange> resTypes) override;
         };
     }
 }

--- a/include/xten/Util/Arch.h
+++ b/include/xten/Util/Arch.h
@@ -37,41 +37,41 @@ class AIEv1 : public AbsArchitecture {
     ~AIEv1() {}
 
     // Size in bytes
-    uint64_t getBankSize() {
+    uint64_t getBankSize() override {
         return pow(2, 12);
     }
 
     // Integer
-    uint64_t getNumBanks() {
+    uint64_t getNumBanks() override {
         return 8;
     }
 
     // Size in bytes
-    uint64_t getMemSize() {
+    uint64_t getMemSize() override {
         return getBankSize() * getNumBanks();
     }
 
     // Integer
-    uint64_t getVectSize() {
+    uint64_t getVectSize() override {
         //llvm::outs() << "Vects size is: " << 128 / (xWidth * zWidth) << "\n";
         return 128 / (xWidth * zWidth);
     }
 
     // Bytes per cycles
-    uint64_t getComSpeed() {
+    uint64_t getComSpeed() override {
         return 4;
     }
 
     // Integer, TODO check that
-    uint64_t getPipelineDepth() {
+    uint64_t getPipelineDepth() override {
         return 8;
     }
 
-    uint64_t getNumCores() {
+    uint64_t getNumCores() override {
         return 400;
     }
 
-    uint64_t getClockFrequency() {
+    uint64_t getClockFrequency() override {
         return pow(10, 9);
     }
 };

--- a/lib/Conversion/XTenToAffine.cpp
+++ b/lib/Conversion/XTenToAffine.cpp
@@ -398,8 +398,6 @@ public:
     LLVM_DEBUG(op->getBlock()->print(llvm::outs()));
 
     rewriter.setInsertionPointAfter(op);
-    Type resultTy = op->getOperand(0).getType();
-
     Torch::BaseTensorType tensorType
       = op->getOperand(0).getType().cast<Torch::BaseTensorType>();
 

--- a/lib/Transform/ATenDialectOpStats.cpp
+++ b/lib/Transform/ATenDialectOpStats.cpp
@@ -224,11 +224,7 @@ std::map<std::string, uint64_t> getStatistics(OpT op) {
 // add
 template<>
 std::map<std::string, uint64_t> getStatistics(Torch::AtenAddTensorOp op) {
-  int *a = nullptr;
-  *a++;
   std::map<std::string, uint64_t> toReturn;
-
-  Torch::BaseTensorType resultTy = op.getResult().getType().cast<Torch::BaseTensorType>();
   Torch::BaseTensorType aType = op.getOperand(0).getType().cast<Torch::BaseTensorType>();
   Type bType = op.getOperand(1).getType();
 
@@ -248,7 +244,6 @@ std::map<std::string, uint64_t> getStatistics(Torch::AtenAddTensorOp op) {
   toReturn["writes"] = ofm_volume;
 
   return toReturn;
-
 }
 
 // add_


### PR DESCRIPTION
There were some "easy to fix" compiler warnings that were polluting the build output. This PR addresses those.