### PR TITLE
Fix dependent dialects of xten-to-linalg pass

### DIFF
--- a/include/xten/Conversion/Passes.td
+++ b/include/xten/Conversion/Passes.td
@@ -29,7 +29,10 @@ def XTenToLinalg : Pass<"xten-to-linalg", "ModuleOp"> {
   let constructor = "xilinx::xten::createXTenToLinalgPass()";
   let dependentDialects = [
     "linalg::LinalgDialect",
-    "bufferization::BufferizationDialect"
+    "bufferization::BufferizationDialect",
+    "memref::MemRefDialect",
+    "mlir::torch::Torch::TorchDialect",
+    "mlir::torch::TorchConversion::TorchConversionDialect",
   ];
 }
 

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -13,7 +13,10 @@
 
 #include "mlir/Pass/Pass.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
 
 namespace xilinx {
 namespace xten {

--- a/lib/Conversion/XTenToLinalg.cpp
+++ b/lib/Conversion/XTenToLinalg.cpp
@@ -235,13 +235,6 @@ public:
   XTenToLinalgPass() = default;
   XTenToLinalgPass(const XTenToLinalgPass &pass) {};
 
-  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
-     registry.insert<memref::MemRefDialect>();
-     registry.insert<linalg::LinalgDialect>();
-     registry.insert<Torch::TorchDialect,
-                     TorchConversion::TorchConversionDialect>();
-  }
-
   void runOnOperation() override {
 
     auto module = getOperation();


### PR DESCRIPTION
Followup on #8: I didn't notice that the pass was overriding the `getDependentDialects` method, so that the values set in the tablegen file were ignored. Therefore the missing bufferization dialect was still missing,