### PR TITLE
make the body of a subgraph optional

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -49,6 +49,14 @@ def XTenNN_SubgraphOp : XTenNN_Op<"subgraph", [
         This allows code motion between the parent and anonymous
         subgraphs.
 
+        The meaning of the subgraph is described using both attributes and its
+        body. If the body is present, the contents of the body can replace the
+        subgraph operation without any change to what would be computed.
+        The body is not required: in that case the attributes must be enough
+        to identify the operation of the subgraph. (This resembles an func.func
+        without a body: there may be a body in a different module or the
+        compiler may know how to implement it when it is an intrinsic.)
+
         Example:
         ```mlir
         func.func @subgraph(%arg0:  tensor<2xi64>) ->  tensor<2xi64> {
@@ -63,7 +71,7 @@ def XTenNN_SubgraphOp : XTenNN_Op<"subgraph", [
 
     let arguments = (ins Variadic<AnyType>:$captures);
     let results = (outs Variadic<AnyType>:$results);
-    let regions = (region SizedRegion<1>:$content);
+    let regions = (region MaxSizedRegion<1>:$content);
 
     let hasCustomAssemblyFormat = 1;
     let hasVerifier = 1;

--- a/include/xten/Dialect/XTenNN/Interfaces/EnclaveOpInterface.td
+++ b/include/xten/Dialect/XTenNN/Interfaces/EnclaveOpInterface.td
@@ -38,6 +38,19 @@ def XTenNN_EnclaveOp : OpInterface<"EnclaveOp"> {
             /*defaultImplementation=*/[{ return $_op.getOperands(); }]
         >,
         InterfaceMethod<
+            /*desc=*/[{Gets the enclave body block, if present.}],
+            /*retTy=*/"::mlir::Block *",
+            /*methodName=*/"getOptionalEnclaveBody",
+            /*args=*/(ins),
+            /*methodBody=*/"",
+            /*defaultImplementation=*/[{
+                auto &region = $_op->getRegion(0);
+                if (region.hasOneBlock())
+                    return &region.front();
+                return {};
+            }]
+        >,
+        InterfaceMethod<
             /*desc=*/[{Gets the enclave body block.}],
             /*retTy=*/"::mlir::Block &",
             /*methodName=*/"getEnclaveBody",

--- a/lib/Dialect/XTenNN/Interfaces/EnclaveOpInterface.cpp
+++ b/lib/Dialect/XTenNN/Interfaces/EnclaveOpInterface.cpp
@@ -87,6 +87,10 @@ void amd::xten_nn::enclave_interface_defaults::uncapture(
 
 LogicalResult amd::xten_nn::enclave_interface_defaults::verify(Operation *op) {
   auto self = cast<EnclaveOp>(op);
+  if (! self.getOptionalEnclaveBody()) {
+    // Nothing to check.
+    return success();
+  }
 
   if (self.getEnclaveBody().empty() ||
       !isa<RegionBranchTerminatorOpInterface>(&self.getEnclaveBody().back()))

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -10,3 +10,9 @@ func.func @subgraph(%arg0:  tensor<2xi64>) ->  tensor<2xi64> {
     } -> tensor<2xi64>
     return %sum :  tensor<2xi64>
 }
+// -----
+// CHECK-LABEL: xten_nn.subgraph
+func.func @subgraph_empty(%arg0:  tensor<2xi64>) ->  tensor<2xi64> {
+    %sum = xten_nn.subgraph (%arg0 : tensor<2xi64>) -> tensor<2xi64>
+    return %sum :  tensor<2xi64>
+}


### PR DESCRIPTION
In many uses, subgraph operations are fully specified by the provided attributes, and the body is expected to be semantically equivalent in dialects with wider support. When the equivalence cannot be easily maintained, or is no longer needed, then it should be removable. This PR enables subgraphs without bodies.