### PR TITLE
ReflectPadOp lowering from xten_nn to torch 

### DIFF
--- a/lib/Conversion/XTenNNToTorch.cpp
+++ b/lib/Conversion/XTenNNToTorch.cpp
@@ -149,6 +149,32 @@ ValueRange groupConv2dToTorch(GroupConv2dOp op, GroupConv2dOp::Adaptor adaptor,
       ->getResults();
 }
 
+ValueRange gridSampleToTorch(GridSampleOp op, GridSampleOp::Adaptor adaptor,
+                              ArrayRef<Type> types, ValueRange values,
+                              ConversionPatternRewriter &rewriter) {
+  auto loc = op->getLoc();
+  auto opName = rewriter.getStringAttr("onnx.GridSample");
+  llvm::SmallVector<Value> operands = {values[0], values[1]}; 
+  // Creates NamedAttr with blocksize and mode
+  std::string modeStr = "bilinear";
+  if (adaptor.getMode() == 1){
+    modeStr = "nearest";
+  } 
+  std::string padModeStr = "zeros";
+  if (adaptor.getPaddingMode() == 1) {
+    padModeStr = "border";
+  }
+  auto modeAttr = rewriter.getNamedAttr("torch.onnx.mode", rewriter.getStringAttr(modeStr));
+  auto padModeAttr = rewriter.getNamedAttr("torch.onnx.padding_mode", rewriter.getStringAttr(padModeStr));
+  auto alignCornersAttr = rewriter.getNamedAttr("torch.onnx.align_corners", adaptor.getAlignCornersAttr());
+  auto nameAttr = rewriter.getNamedAttr("name", opName);
+  llvm::SmallVector<NamedAttribute> attrs ={nameAttr, modeAttr, padModeAttr, alignCornersAttr};
+
+  return rewriter
+      .create<Torch::OperatorOp>(loc, types[0], operands, attrs, op->getRegions().size())
+      ->getResults();
+}
+
 ValueRange depthToSpaceToTorch(DepthToSpaceOp op, DepthToSpaceOp::Adaptor adaptor,
                               ArrayRef<Type> types, ValueRange values,
                               ConversionPatternRewriter &rewriter) {
@@ -252,6 +278,8 @@ struct ConvertXTenNNToTorch
     patterns.add<ApplyXTenNNToTorch<GroupConv2dOp, groupConv2dToTorch>>(
         context);
     patterns.add<ApplyXTenNNToTorch<DepthToSpaceOp, depthToSpaceToTorch>>(
+        context);
+    patterns.add<ApplyXTenNNToTorch<GridSampleOp, gridSampleToTorch>>(
         context);
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns))))

--- a/lib/Conversion/XTenNNToTorch.cpp
+++ b/lib/Conversion/XTenNNToTorch.cpp
@@ -5,6 +5,7 @@
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
@@ -36,12 +37,16 @@ Value toTorchTensorTypeCast(PatternRewriter &rewriter, Value input) {
 
   auto tensorTy = dyn_cast<ShapedType>(input.getType());
   auto sizes = tensorTy.getShape();
+  auto tensorEltTy = tensorTy.getElementType();
+  if (tensorEltTy.isSignlessInteger()) {
+    tensorEltTy = rewriter.getIntegerType(tensorTy.getElementTypeBitWidth(), true);
+  }
 
   return rewriter
       .create<TorchConversion::FromBuiltinTensorOp>(
           input.getLoc(),
           mlir::torch::Torch::ValueTensorType::get(input.getContext(), sizes,
-                                                   tensorTy.getElementType()),
+                                                   tensorEltTy),
           input)
       .getResult();
 }
@@ -146,6 +151,25 @@ ValueRange groupConv2dToTorch(GroupConv2dOp op, GroupConv2dOp::Adaptor adaptor,
   return rewriter
       .create<Torch::AtenConv2dOp>(loc, types[0], newInput, newWeights, newBias,
                                    stride, conv2dPads, dilation, group)
+      ->getResults();
+}
+
+ValueRange padReflectToTorch(ReflectPadOp op, ReflectPadOp::Adaptor adaptor,
+                              ArrayRef<Type> types, ValueRange values,
+                              ConversionPatternRewriter &rewriter) {
+  auto loc = op->getLoc();
+  auto opName = rewriter.getStringAttr("onnx.Pad");
+  // No need to create a `constant` operand if we only have reflect padding since it's unused.
+  // Necessary if we start supporting more modes.
+  llvm::SmallVector<Value> operands = {values[0], values[1]}; 
+  // Creates NamedAttr with blocksize and mode
+  std::string modeStr = "reflect";
+  auto modeAttr = rewriter.getNamedAttr("torch.onnx.mode", rewriter.getStringAttr(modeStr));
+  auto nameAttr = rewriter.getNamedAttr("name", opName);
+  llvm::SmallVector<NamedAttribute> attrs ={nameAttr, modeAttr};
+
+  return rewriter
+      .create<Torch::OperatorOp>(loc, types[0], operands, attrs, op->getRegions().size())
       ->getResults();
 }
 
@@ -281,6 +305,9 @@ struct ConvertXTenNNToTorch
         context);
     patterns.add<ApplyXTenNNToTorch<GridSampleOp, gridSampleToTorch>>(
         context);
+    patterns.add<ApplyXTenNNToTorch<ReflectPadOp, padReflectToTorch>>(
+        context);
+
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns))))
       signalPassFailure();

--- a/test/Conversion/XTenNNToTorch/grid_sample.mlir
+++ b/test/Conversion/XTenNNToTorch/grid_sample.mlir
@@ -1,4 +1,3 @@
-
 // (c) Copyright 2024 Advanced Micro Devices, Inc. All Rights reserved.
 
 // RUN: aten-opt --convert-xtennn-to-torch  -split-input-file %s | FileCheck %s

--- a/test/Conversion/XTenNNToTorch/grid_sample.mlir
+++ b/test/Conversion/XTenNNToTorch/grid_sample.mlir
@@ -1,0 +1,29 @@
+
+// (c) Copyright 2024 Advanced Micro Devices, Inc. All Rights reserved.
+
+// RUN: aten-opt --convert-xtennn-to-torch  -split-input-file %s | FileCheck %s
+
+func.func @gridsample_default_bf16(%arg0: tensor<1x32x576x384xbf16>, %arg1: tensor<1x64x16x2xbf16>) -> tensor<1x32x64x16xbf16> {
+    %0 = xten_nn.grid_sample %arg0, %arg1 {align_corners = 1 : i64, mode = 0 : i64, padding_mode = 0 : i64} : (tensor<1x32x576x384xbf16>, tensor<1x64x16x2xbf16>) -> tensor<1x32x64x16xbf16>
+    return %0 : tensor<1x32x64x16xbf16>
+}
+// CHECK-LABEL:  func.func @gridsample_default_bf16
+// CHECK-SAME:      (%[[ARG0:.*]]: tensor<1x32x576x384xbf16>, %[[ARG1:.*]]: tensor<1x64x16x2xbf16>) -> tensor<1x32x64x16xbf16> {
+// CHECK:    %[[VAL_0:.*]] = torch_c.from_builtin_tensor %[[ARG0]] : tensor<1x32x576x384xbf16> -> !torch.vtensor<[1,32,576,384],bf16>
+// CHECK:    %[[VAL_1:.*]] = torch_c.from_builtin_tensor %[[ARG1]] : tensor<1x64x16x2xbf16> -> !torch.vtensor<[1,64,16,2],bf16>
+// CHECK:    %[[VAL_2:.*]] = torch.operator "onnx.GridSample"(%[[VAL_0]], %[[VAL_1]]) {torch.onnx.align_corners = 1 : i64, torch.onnx.mode = "bilinear", torch.onnx.padding_mode = "zeros"} : (!torch.vtensor<[1,32,576,384],bf16>, !torch.vtensor<[1,64,16,2],bf16>) -> !torch.vtensor<[1,32,64,16],bf16>
+// CHECK:    %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[1,32,64,16],bf16> -> tensor<1x32x64x16xbf16>
+// CHECK:    return %[[VAL_3]] : tensor<1x32x64x16xbf16>
+
+// -----
+
+func.func @gridsample_default_f32(%arg0: tensor<1x32x576x384xf32>, %arg1: tensor<1x64x16x2xf32>) -> tensor<1x32x64x16xf32> {
+    %0 = xten_nn.grid_sample %arg0, %arg1 {align_corners = 1 : i64, mode = 0 : i64, padding_mode = 0 : i64} : (tensor<1x32x576x384xf32>, tensor<1x64x16x2xf32>) -> tensor<1x32x64x16xf32>
+    return %0 : tensor<1x32x64x16xf32>
+}
+// CHECK-LABEL:  func.func @gridsample_default_f32
+// CHECK-SAME:      (%[[ARG0:.*]]: tensor<1x32x576x384xf32>, %[[ARG1:.*]]: tensor<1x64x16x2xf32>) -> tensor<1x32x64x16xf32> {
+// CHECK:    %[[VAL_0:.*]] = torch_c.from_builtin_tensor %[[ARG0]] : tensor<1x32x576x384xf32> -> !torch.vtensor<[1,32,576,384],f32>
+// CHECK:    %[[VAL_1:.*]] = torch_c.from_builtin_tensor %[[ARG1]] : tensor<1x64x16x2xf32> -> !torch.vtensor<[1,64,16,2],f32>
+// CHECK:    %[[VAL_2:.*]] = torch.operator "onnx.GridSample"(%[[VAL_0]], %[[VAL_1]]) {torch.onnx.align_corners = 1 : i64, torch.onnx.mode = "bilinear", torch.onnx.padding_mode = "zeros"} : (!torch.vtensor<[1,32,576,384],f32>, !torch.vtensor<[1,64,16,2],f32>) -> !torch.vtensor<[1,32,64,16],f32>
+// CHECK:    %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[1,32,64,16],f32> -> tensor<1x32x64x16xf32>

--- a/test/Conversion/XTenNNToTorch/reflect_pad.mlir
+++ b/test/Conversion/XTenNNToTorch/reflect_pad.mlir
@@ -2,12 +2,12 @@
 
 // RUN: aten-opt --convert-xtennn-to-torch  -split-input-file %s | FileCheck %s
 
-func.func @gridsample_default_bf16(%arg0: tensor<1x32x122x122xbf16>) -> tensor<1x32x124x124xbf16> {
+func.func @reflect_pad_bf16(%arg0: tensor<1x32x122x122xbf16>) -> tensor<1x32x124x124xbf16> {
     %pad = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
     %reflect_pad = xten_nn.reflect_pad %arg0, %pad {LayerName = "Pad_282", OutputName = "Pad_282"} : (tensor<1x32x122x122xbf16>, tensor<8xi64>) -> (tensor<1x32x124x124xbf16>)
     return %reflect_pad : tensor<1x32x124x124xbf16>
 }
-// CHECK-LABEL:  func.func @gridsample_default_bf16
+// CHECK-LABEL:  func.func @reflect_pad_bf16
 // CHECK-SAME:      (%[[ARG:.*]]: tensor<1x32x122x122xbf16>) -> tensor<1x32x124x124xbf16> {
 // CHECK:    %[[PADS:.*]] = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
 // CHECK:    %[[FROM_ARG:.*]] = torch_c.from_builtin_tensor %[[ARG]] : tensor<1x32x122x122xbf16> -> !torch.vtensor<[1,32,122,122],bf16>
@@ -17,12 +17,12 @@ func.func @gridsample_default_bf16(%arg0: tensor<1x32x122x122xbf16>) -> tensor<1
 // CHECK:    return %[[TO]] : tensor<1x32x124x124xbf16>
 
 // -----
-func.func @gridsample_default_f32(%arg0: tensor<1x32x122x122xf32>) -> tensor<1x32x124x124xf32> {
+func.func @reflect_pad_f32(%arg0: tensor<1x32x122x122xf32>) -> tensor<1x32x124x124xf32> {
     %pad = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
     %reflect_pad = xten_nn.reflect_pad %arg0, %pad {LayerName = "Pad_282", OutputName = "Pad_282"} : (tensor<1x32x122x122xf32>, tensor<8xi64>) -> (tensor<1x32x124x124xf32>)
     return %reflect_pad : tensor<1x32x124x124xf32>
 }
-// CHECK-LABEL:  func.func @gridsample_default_f32
+// CHECK-LABEL:  func.func @reflect_pad_f32
 // CHECK-SAME:      (%[[ARG:.*]]: tensor<1x32x122x122xf32>) -> tensor<1x32x124x124xf32> {
 // CHECK:    %[[PADS:.*]] = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
 // CHECK:    %[[FROM_ARG:.*]] = torch_c.from_builtin_tensor %[[ARG]] : tensor<1x32x122x122xf32> -> !torch.vtensor<[1,32,122,122],f32>

--- a/test/Conversion/XTenNNToTorch/reflect_pad.mlir
+++ b/test/Conversion/XTenNNToTorch/reflect_pad.mlir
@@ -1,0 +1,32 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc. All Rights reserved.
+
+// RUN: aten-opt --convert-xtennn-to-torch  -split-input-file %s | FileCheck %s
+
+func.func @gridsample_default_bf16(%arg0: tensor<1x32x122x122xbf16>) -> tensor<1x32x124x124xbf16> {
+    %pad = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %reflect_pad = xten_nn.reflect_pad %arg0, %pad {LayerName = "Pad_282", OutputName = "Pad_282"} : (tensor<1x32x122x122xbf16>, tensor<8xi64>) -> (tensor<1x32x124x124xbf16>)
+    return %reflect_pad : tensor<1x32x124x124xbf16>
+}
+// CHECK-LABEL:  func.func @gridsample_default_bf16
+// CHECK-SAME:      (%[[ARG:.*]]: tensor<1x32x122x122xbf16>) -> tensor<1x32x124x124xbf16> {
+// CHECK:    %[[PADS:.*]] = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
+// CHECK:    %[[FROM_ARG:.*]] = torch_c.from_builtin_tensor %[[ARG]] : tensor<1x32x122x122xbf16> -> !torch.vtensor<[1,32,122,122],bf16>
+// CHECK:    %[[FROM_PADS:.*]] = torch_c.from_builtin_tensor %[[PADS]] : tensor<8xi64> -> !torch.vtensor<[8],si64>
+// CHECK:    %[[OP:.*]] = torch.operator "onnx.Pad"(%[[FROM_ARG]], %[[FROM_PADS]]) {torch.onnx.mode = "reflect"} : (!torch.vtensor<[1,32,122,122],bf16>, !torch.vtensor<[8],si64>) -> !torch.vtensor<[1,32,124,124],bf16>
+// CHECK:    %[[TO:.*]] = torch_c.to_builtin_tensor %[[OP]] : !torch.vtensor<[1,32,124,124],bf16> -> tensor<1x32x124x124xbf16>
+// CHECK:    return %[[TO]] : tensor<1x32x124x124xbf16>
+
+// -----
+func.func @gridsample_default_f32(%arg0: tensor<1x32x122x122xf32>) -> tensor<1x32x124x124xf32> {
+    %pad = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %reflect_pad = xten_nn.reflect_pad %arg0, %pad {LayerName = "Pad_282", OutputName = "Pad_282"} : (tensor<1x32x122x122xf32>, tensor<8xi64>) -> (tensor<1x32x124x124xf32>)
+    return %reflect_pad : tensor<1x32x124x124xf32>
+}
+// CHECK-LABEL:  func.func @gridsample_default_f32
+// CHECK-SAME:      (%[[ARG:.*]]: tensor<1x32x122x122xf32>) -> tensor<1x32x124x124xf32> {
+// CHECK:    %[[PADS:.*]] = "tosa.const"() <{value = dense<[0, 0, 1, 1, 0, 0, 1, 1]> : tensor<8xi64>}> : () -> tensor<8xi64>
+// CHECK:    %[[FROM_ARG:.*]] = torch_c.from_builtin_tensor %[[ARG]] : tensor<1x32x122x122xf32> -> !torch.vtensor<[1,32,122,122],f32>
+// CHECK:    %[[FROM_PADS:.*]] = torch_c.from_builtin_tensor %[[PADS]] : tensor<8xi64> -> !torch.vtensor<[8],si64>
+// CHECK:    %[[OP:.*]] = torch.operator "onnx.Pad"(%[[FROM_ARG]], %[[FROM_PADS]]) {torch.onnx.mode = "reflect"} : (!torch.vtensor<[1,32,122,122],f32>, !torch.vtensor<[8],si64>) -> !torch.vtensor<[1,32,124,124],f32>
+// CHECK:    %[[TO:.*]] = torch_c.to_builtin_tensor %[[OP]] : !torch.vtensor<[1,32,124,124],f32> -> tensor<1x32x124x124xf32>
+// CHECK:    return %[[TO]] : tensor<1x32x124x124xf32>


### PR DESCRIPTION
Ignore the gridsample changes, they've been merged to a merged branch so it didn't reach feature/fused-ops. I'll use this PR to bring the commits