### PR TITLE
feat: allow XTenNN ops to support the same types as ONNX operators.

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -134,7 +134,7 @@ def XTenNN_QuantizeOp: XTenNN_Op<"quantize", [
     SI32Attr:$shift
   );
 
-  let results = (outs XTenNN_AnyTensorSignlessOrUnsignedInteger:$output);
+  let results = (outs XTenNN_AnySignlessOrUnsignedIntegerTensor:$output);
 
   let assemblyFormat = [{ `(`$input `:` type($input)`)` attr-dict `->` type($output) }];
 
@@ -159,7 +159,7 @@ def XTenNN_DequantizeOp: XTenNN_Op<"dequantize", [
   }];
 
   let arguments = (ins
-    XTenNN_AnyTensorSignlessOrUnsignedInteger:$input,
+    XTenNN_AnySignlessOrUnsignedIntegerTensor:$input,
     SI32Attr:$shift
   );
 
@@ -187,15 +187,15 @@ def XTenNN_GroupQuantizeOp: XTenNN_Op<"group_quantize", [
   }];
 
   let arguments = (ins
-    XTenNN_AnyTensorFloat:$input,
-    XTenNN_AnyTensorFloat:$scales,
-    XTenNN_AnyTensorSignlessOrUnsignedInteger:$zeros,
+    XTenNN_AnyFloatTensor:$input,
+    XTenNN_AnyFloatTensor:$scales,
+    XTenNN_AnySignlessOrUnsignedIntegerTensor:$zeros,
     SI32Attr:$min,
     SI32Attr:$max,
     SI32Attr:$bits
 );
 
-  let results = (outs XTenNN_AnyTensorSignlessOrUnsignedInteger:$quants);
+  let results = (outs XTenNN_AnySignlessOrUnsignedIntegerTensor:$quants);
 
   let assemblyFormat = [{ `(`$input `:` type($input) `,` $scales `:` type($scales) `,` $zeros `:` type($zeros)`)` attr-dict `->` type($quants) }];
 
@@ -219,15 +219,15 @@ def XTenNN_GroupDequantizeOp: XTenNN_Op<"group_dequantize", [
   }];
 
   let arguments = (ins
-    XTenNN_AnyTensorSignlessOrUnsignedInteger:$quants,
-    XTenNN_AnyTensorFloat:$scales,
-    XTenNN_AnyTensorSignlessOrUnsignedInteger:$zeros,
+    XTenNN_AnySignlessOrUnsignedIntegerTensor:$quants,
+    XTenNN_AnyFloatTensor:$scales,
+    XTenNN_AnySignlessOrUnsignedIntegerTensor:$zeros,
     SI32Attr:$min,
     SI32Attr:$max,
     SI32Attr:$bits
   );
 
-  let results = (outs XTenNN_AnyTensorFloat:$output);
+  let results = (outs XTenNN_AnyFloatTensor:$output);
 
   let assemblyFormat = [{ `(`$quants `:` type($quants) `,` $scales `:` type($scales)`,` $zeros `:` type($zeros)`)` attr-dict `->` type($output) }];
 
@@ -261,7 +261,6 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
 // Ops that are missing from the TOSA standard
 //===----------------------------------------------------------------------===//
 
-def AnyFloatTensor : TensorOf<[AnyFloat]>;
 def TosaExtension : NativeOpTrait<"TosaExtension">;
 def ElementwiseUnary : NativeOpTrait<"ElementwiseUnary">;
 def ElementwiseBinary : NativeOpTrait<"ElementwiseBinary">;
@@ -275,11 +274,11 @@ def XtenNN_Atan2Op: XTenNN_Op<"atan2", [Pure, TosaExtension, ElementwiseBinary, 
     Calculate the arctangent of input/other of a given pair of tensor element-wise.
   }];
   let arguments = (ins
-    AnyFloatTensor:$input,
-    AnyFloatTensor:$other
+    XTenNN_AnyFloatTensor:$input,
+    XTenNN_AnyFloatTensor:$other
   );
   let results = (outs
-    AnyFloatTensor:$output
+    XTenNN_AnyFloatTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -292,15 +291,15 @@ def XtenNN_GridSampleOp: XTenNN_Op<"grid_sample", [Pure]> {
     the interpolation of the flow-field grid and the input.
   }];
   let arguments = (ins
-    XTenNN_AnyTensorFloat:$X,
-    XTenNN_AnyTensorFloat:$grid,
+    AnyTensor:$X,
+    AnyTensor:$grid,
     I64Attr:$align_corners,
     I64Attr:$mode,
     I64Attr:$padding_mode
   );
 
   let results = (outs
-    XTenNN_AnyTensorFloat:$output
+    AnyTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -319,13 +318,13 @@ def XtenNN_DepthToSpaceOp: XTenNN_Op<"depth_to_space", [Pure, TosaExtension]> {
     - 2: CRD: Elements rearranged in order Column - Row - Depth
   }];
   let arguments = (ins
-    4DTensorOf<[BF16, F32, I8]>:$X,
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$X,
     I64Attr:$blocksize,
     I64Attr:$mode
   );
 
   let results = (outs
-    4DTensorOf<[BF16, F32, I8]>:$Y
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$Y
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -349,12 +348,12 @@ def XtenNN_ReflectPadOp: XTenNN_Op<"reflect_pad", [TosaExtension]> {
 
   }];
   let arguments = (ins
-    4DTensorOf<[BF16, F32]>:$input,
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$input,
     TensorOf<[I64]>:$pads
   );
 
   let results = (outs
-    4DTensorOf<[BF16, F32]>:$Y
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$Y
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -372,16 +371,16 @@ def XtenNN_GroupConv2dOp: XTenNN_Op<"group_conv2d", [Pure, TosaExtension]> {
     arrays denote the initial and end padding for H and W dimensions respectively.
   }];
   let arguments = (ins
-    4DTensorOf<[BF16, F32]>:$input,
-    4DTensorOf<[BF16, F32]>:$weights,
-    1DTensorOf<[BF16, F32]>:$bias,
+    4DTensorOf<[AnyFloat]>:$input,
+    4DTensorOf<[AnyFloat]>:$weights,
+    1DTensorOf<[AnyFloat]>:$bias,
     ArrayAttr<2>:$pad,
     I64DenseArrayAttr<2>:$stride,
     I64DenseArrayAttr<2>:$dilation,
     I64Attr:$group
   );
   let results = (outs
-    4DTensorOf<[BF16, F32]>:$output
+    4DTensorOf<[AnyFloat]>:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -396,11 +395,11 @@ def XtenNN_EluOp: XTenNN_Op<"elu", [Pure, TosaExtension, ElementwiseUnary, SameO
               alpha * (exp(x)-1), if x <= 0
   }];
   let arguments = (ins
-    AnyFloatTensor:$input,
+    XTenNN_AnyFloatTensor:$input,
     F32Attr:$alpha
   );
   let results = (outs
-    AnyFloatTensor:$output
+    XTenNN_AnyFloatTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -412,10 +411,10 @@ def XtenNN_MishOp: XTenNN_Op<"mish", [Pure, TosaExtension, ElementwiseUnary, Sam
     Calculate the mish operation (Self Regularized Non-Monotonic Neural Activation Function) of the given input tensor element-wise.
   }];
   let arguments = (ins
-    AnyFloatTensor:$input
+    XTenNN_AnyFloatTensor:$input
   );
   let results = (outs
-    AnyFloatTensor:$output
+    XTenNN_AnyFloatTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -445,7 +444,7 @@ def XtenNN_ResizeOp: XTenNN_Op<"resize", [Pure, TosaExtension]> {
         - 2: round_prefer_floor
   }];
   let arguments = (ins
-    4DTensorOf<[BF16, F32]>:$X,
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$X,
     DenseF32ArrayAttr:$scales,
     I64Attr:$coordinate_transformation_mode,
     I64Attr:$mode,
@@ -453,7 +452,7 @@ def XtenNN_ResizeOp: XTenNN_Op<"resize", [Pure, TosaExtension]> {
   );
 
   let results = (outs
-    4DTensorOf<[BF16, F32]>:$Y
+    4DTensorOf<[XTenNN_AnyIntegerOrFloat]>:$Y
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -468,10 +467,10 @@ def XtenNN_RoundOp: XTenNN_Op<"round", [Pure, TosaExtension, ElementwiseUnary, S
     In case of halves, the rule is to round them to the nearest even integer as does the 'round' operation in torch and onnx.
   }];
   let arguments = (ins
-    AnyFloatTensor:$input
+    XTenNN_AnyFloatTensor:$input
   );
   let results = (outs
-    AnyFloatTensor:$output
+    XTenNN_AnyFloatTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -484,10 +483,10 @@ def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, Sam
     If the input is a NaN, the output will be a copy of the input element.
   }];
   let arguments = (ins
-    AnyFloatTensor:$input
+    XTenNN_AnyFloatTensor:$input
   );
   let results = (outs
-    AnyFloatTensor:$output
+    XTenNN_AnyFloatTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];

--- a/include/xten/Dialect/XTenNN/IR/XTenNNTypes.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNTypes.td
@@ -15,14 +15,13 @@
 
 include "xten/Dialect/XTenNN/IR/XTenNNBase.td"
 
-def XTenNN_AnyTensorSignlessOrUnsignedInteger : TensorOf<
+def XTenNN_AnySignlessOrUnsignedIntegerTensor : TensorOf<
     [AnySignlessInteger, AnyUnsignedInteger], 
     [], 
     "signless-or-unsigned-tensor">;
 
-def XTenNN_AnyTensorFloat : TensorOf<
-    [AnyFloat],
-    [],
-    "signless-or-unsigned-tensor">;
+def XTenNN_AnyFloatTensor : TensorOf<[AnyFloat]>;
+
+def XTenNN_AnyIntegerOrFloat : AnyTypeOf<[AnySignlessInteger, AnyFloat], "Integer or Float">;
 
 #endif // XTENNN_TYPES

--- a/include/xten/Dialect/XTenNN/IR/XTenNNTypes.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNTypes.td
@@ -22,6 +22,6 @@ def XTenNN_AnySignlessOrUnsignedIntegerTensor : TensorOf<
 
 def XTenNN_AnyFloatTensor : TensorOf<[AnyFloat]>;
 
-def XTenNN_AnyIntegerOrFloat : AnyTypeOf<[AnySignlessInteger, AnyFloat], "Integer or Float">;
+def XTenNN_AnyIntegerOrFloat : AnyTypeOf<[AnyInteger, AnyFloat], "Integer or Float">;
 
 #endif // XTENNN_TYPES


### PR DESCRIPTION
- Renames `XTenNN_AnyTensorSignlessOrUnsignedInteger` to `XTenNN_AnySignlessOrUnsignedIntegerTensor`
- Renames `XTenNN_AnyTensorFloat/AnyFloatTensor` to `XTenNN_AnyFloatTensor`
- `GroupConv`, `DepthToSpace`, `ReflectPad` and `Resize` to allow any 4D Int and Float Type.
- GridSample to allow any tensor type.