### PR TITLE
feat: allow integer types in Sign and Round operations (feature/fused-ops)

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -467,10 +467,10 @@ def XtenNN_RoundOp: XTenNN_Op<"round", [Pure, TosaExtension, ElementwiseUnary, S
     In case of halves, the rule is to round them to the nearest even integer as does the 'round' operation in torch and onnx.
   }];
   let arguments = (ins
-    XTenNN_AnyFloatTensor:$input
+    AnyTensor:$input
   );
   let results = (outs
-    XTenNN_AnyFloatTensor:$output
+    AnyTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
@@ -483,10 +483,10 @@ def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, Sam
     If the input is a NaN, the output will be a copy of the input element.
   }];
   let arguments = (ins
-    XTenNN_AnyFloatTensor:$input
+    AnyTensor:$input
   );
   let results = (outs
-    XTenNN_AnyFloatTensor:$output
+    AnyTensor:$output
   );
 
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];

--- a/test/Dialect/XTenNN/ops_invalid.mlir
+++ b/test/Dialect/XTenNN/ops_invalid.mlir
@@ -24,19 +24,3 @@ func.func @mish_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
     %0 = xten_nn.mish %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
     return %0 : tensor<1x10xi4>
 }
-
-// -----
-
-func.func @round_int(%arg0: tensor<1x10xsi32>) -> tensor<1x10xsi32> {
-    // expected-error@+1 {{op operand #0 must be tensor of floating-point values, but got 'tensor<1x10xsi32>'}}
-    %0 = xten_nn.round %arg0 : (tensor<1x10xsi32>) -> tensor<1x10xsi32>
-    return %0 : tensor<1x10xsi32>
-}
-
-// -----
-
-func.func @sign_int(%arg0: tensor<1x10xi4>) -> tensor<1x10xi4> {
-    // expected-error@+1 {{op operand #0 must be tensor of floating-point values, but got 'tensor<1x10xi4>'}}
-    %0 = xten_nn.sign %arg0 : (tensor<1x10xi4>) -> tensor<1x10xi4>
-    return %0 : tensor<1x10xi4>
-}


### PR DESCRIPTION
`Sign` may work with integer types, and although `round` for integer isn't supported by Onnx, Torch allows it.