### PR TITLE
feat: legalize onnx conv2d transpose to xtennn

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -492,4 +492,28 @@ def XtenNN_SignOp: XTenNN_Op<"sign", [Pure, TosaExtension, ElementwiseUnary, Sam
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
 }
 
+def XtenNN_ConvTransposeOp: XTenNN_Op<"ConvTranspose",[Pure, TosaExtension]> {
+  let summary = "Perform ConvTranspose operation";
+  let description = [{
+    This operation is equivalent to `onnx.ConvTranspose` and computes the ConvTranspose.
+  }];
+
+  let arguments = (ins
+    4DTensorOf<[AnyFloat]>:$input,
+    4DTensorOf<[AnyFloat]>:$weights,
+    1DTensorOf<[AnyFloat]>:$bias,
+    ArrayAttr<2>:$pad,
+    I64DenseArrayAttr<2>:$output_padding,
+    I64DenseArrayAttr<2>:$stride,
+    I64DenseArrayAttr<2>:$dilation,
+    I64Attr:$group
+  );
+
+  let results = (outs
+    4DTensorOf<[AnyFloat]>:$output
+  );
+
+  let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
+}
+
 #endif // XTENNN_OPS

--- a/lib/Conversion/XTenNNToTorch.cpp
+++ b/lib/Conversion/XTenNNToTorch.cpp
@@ -71,26 +71,27 @@ Value toBuiltinTensorTypeCast(OpBuilder &builder, Value val, Type type) {
                                                                    type, val);
 }
 
-struct Conv2dPadding {
+struct Padding2d {
   std::array<int64_t, 2> hPadding;
   std::array<int64_t, 2> wPadding;
 
   [[nodiscard]] bool isSymmetric() const {
     return hPadding[0] == hPadding[1] && wPadding[0] == wPadding[1];
   }
+
+  template <typename T>
+  static Padding2d get(T adaptor) {
+    auto pad = adaptor.getPad();
+    assert(pad.size() == 2 && "expected 2 elements by definition");
+
+    auto hPadding = cast<DenseI64ArrayAttr>(pad[0]);
+    auto wPadding = cast<DenseI64ArrayAttr>(pad[1]);
+    assert(hPadding.size() == 2 && "expected 2 elements by definition");
+    assert(wPadding.size() == 2 && "expected 2 elements by definition");
+
+    return {{hPadding[0], hPadding[1]}, {wPadding[0], wPadding[1]}};
+  }
 };
-
-Conv2dPadding getPadding(GroupConv2dOp::Adaptor adaptor) {
-  auto pad = adaptor.getPad();
-  assert(pad.size() == 2 && "expected 2 elements by definition");
-
-  auto hPadding = cast<DenseI64ArrayAttr>(pad[0]);
-  auto wPadding = cast<DenseI64ArrayAttr>(pad[1]);
-  assert(hPadding.size() == 2 && "expected 2 elements by definition");
-  assert(wPadding.size() == 2 && "expected 2 elements by definition");
-
-  return {{hPadding[0], hPadding[1]}, {wPadding[0], wPadding[1]}};
-}
 
 template <typename SrcOpT>
 std::optional<ValueRange> oneToOneXTenNNToTorch(SrcOpT op,
@@ -113,7 +114,7 @@ std::optional<ValueRange> groupConv2dToTorch(GroupConv2dOp op, GroupConv2dOp::Ad
 
   auto newInput = values[0];
   mlir::Value conv2dPads;
-  Conv2dPadding structPadding = getPadding(adaptor);
+  auto structPadding = Padding2d::get(adaptor);
   if (!structPadding.isSymmetric()) {
     // Padding is not symmetric which is the only mode aten conv2d op supports.
     // We circumvent this problem by adding a padding operation
@@ -160,6 +161,37 @@ std::optional<ValueRange> groupConv2dToTorch(GroupConv2dOp op, GroupConv2dOp::Ad
   return rewriter
       .create<Torch::AtenConv2dOp>(loc, types[0], newInput, newWeights, newBias,
                                    stride, conv2dPads, dilation, group)
+      ->getResults();
+}
+
+std::optional<ValueRange>
+convTranspose2dToTorch(ConvTransposeOp op, ConvTransposeOp::Adaptor adaptor,
+                       ArrayRef<Type> types, ValueRange values,
+                       ConversionPatternRewriter &rewriter) {
+  auto loc = op->getLoc();
+
+  auto newInput = values[0];
+  auto newWeights = values[1];
+  auto newBias = values[2];
+
+  auto stride = Torch::toTorchList(loc, rewriter, adaptor.getStride().vec());
+  auto dilation =
+      Torch::toTorchList(loc, rewriter, adaptor.getDilation().vec());
+  auto group =
+      rewriter.create<Torch::ConstantIntOp>(loc, adaptor.getGroupAttr());
+  auto outputPadding =
+      Torch::toTorchList(loc, rewriter, adaptor.getOutputPadding().vec());
+
+  // TODO: check the order is matched with what torch needs.
+  auto pads = Padding2d::get(adaptor);
+  auto inputPadding = Torch::toTorchList(
+      loc, rewriter,
+      {pads.hPadding[0], pads.hPadding[1], pads.wPadding[0], pads.hPadding[1]});
+
+  return rewriter
+      .create<Torch::AtenConvTranspose2dInputOp>(
+          loc, types[0], newInput, newWeights, newBias, stride, inputPadding,
+          outputPadding, group, dilation)
       ->getResults();
 }
 
@@ -377,11 +409,10 @@ struct ConvertXTenNNToTorch
         context);
     patterns.add<ApplyXTenNNToTorch<DepthToSpaceOp, depthToSpaceToTorch>>(
         context);
-    patterns.add<ApplyXTenNNToTorch<GridSampleOp, gridSampleToTorch>>(
-        context);
-    patterns.add<ApplyXTenNNToTorch<ReflectPadOp, padReflectToTorch>>(
-        context);
-    patterns.add<ApplyXTenNNToTorch<ResizeOp, resizeToTorch>>(
+    patterns.add<ApplyXTenNNToTorch<GridSampleOp, gridSampleToTorch>>(context);
+    patterns.add<ApplyXTenNNToTorch<ReflectPadOp, padReflectToTorch>>(context);
+    patterns.add<ApplyXTenNNToTorch<ResizeOp, resizeToTorch>>(context);
+    patterns.add<ApplyXTenNNToTorch<ConvTransposeOp, convTranspose2dToTorch>>(
         context);
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns))))
       signalPassFailure();

--- a/lib/Conversion/XTenNNToTorch.cpp
+++ b/lib/Conversion/XTenNNToTorch.cpp
@@ -96,6 +96,33 @@ struct Padding2d {
 
     return {{hPadding[0], hPadding[1]}, {wPadding[0], wPadding[1]}};
   }
+
+  // Zero padding of the input value with hPadding and wPadding using
+  // AtenConstantPadNdOp.
+  Value createZeroAtenPadOp(ConversionPatternRewriter &rewriter, Location loc,
+                            Value input) {
+
+    // Build new vtensor result type
+    auto ty = cast<Torch::ValueTensorType>(input.getType());
+    mlir::Type paddingResultTy;
+    std::optional<llvm::ArrayRef<int64_t>> optSizes = ty.getOptionalSizes();
+    if (optSizes) {
+      auto newSizes = ty.getSizes().vec();
+      newSizes[2] += hPadding[0] + hPadding[1];
+      newSizes[3] += wPadding[0] + wPadding[1];
+      paddingResultTy = Torch::ValueTensorType::get(
+          rewriter.getContext(), newSizes, ty.getOptionalDtype());
+    } else {
+      paddingResultTy = Torch::ValueTensorType::get(
+          rewriter.getContext(), ty.getOptionalSizes(), ty.getOptionalDtype());
+    }
+
+    auto zeroPadValue = rewriter.create<Torch::ConstantIntOp>(loc, 0);
+    auto pads = Torch::toTorchList(
+        loc, rewriter, {hPadding[0], hPadding[1], wPadding[0], wPadding[1]});
+    return rewriter.create<Torch::AtenConstantPadNdOp>(
+        loc, paddingResultTy, input, pads, zeroPadValue);
+  }
 };
 
 template <typename SrcOpT>
@@ -123,29 +150,7 @@ std::optional<ValueRange> groupConv2dToTorch(GroupConv2dOp op, GroupConv2dOp::Ad
   if (!structPadding.isSymmetric()) {
     // Padding is not symmetric which is the only mode aten conv2d op supports.
     // We circumvent this problem by adding a padding operation
-
-    // Build new vtensor result type
-    auto ty = cast<Torch::ValueTensorType>(newInput.getType());
-    mlir::Type paddingResultTy;
-    std::optional<llvm::ArrayRef<int64_t>> optSizes = ty.getOptionalSizes();
-    if (optSizes) {
-      auto newSizes = ty.getSizes().vec();
-      newSizes[2] += structPadding.hPadding[0] + structPadding.hPadding[1];
-      newSizes[3] += structPadding.wPadding[0] + structPadding.wPadding[1];
-      paddingResultTy = Torch::ValueTensorType::get(op->getContext(), newSizes,
-                                                    ty.getOptionalDtype());
-    } else {
-      paddingResultTy = Torch::ValueTensorType::get(
-          op->getContext(), ty.getOptionalSizes(), ty.getOptionalDtype());
-    }
-
-    auto zeroPadValue = rewriter.create<Torch::ConstantIntOp>(loc, 0);
-    auto pads = Torch::toTorchList(
-        loc, rewriter,
-        {structPadding.hPadding[0], structPadding.hPadding[1],
-         structPadding.wPadding[0], structPadding.wPadding[1]});
-    newInput = rewriter.create<Torch::AtenConstantPadNdOp>(
-        loc, paddingResultTy, newInput, pads, zeroPadValue);
+    newInput = structPadding.createZeroAtenPadOp(rewriter, loc, newInput);
 
     // We want zero pad for the Conv2d since we are going to apply it with a
     // padding op
@@ -187,15 +192,21 @@ convTranspose2dToTorch(ConvTransposeOp op, ConvTransposeOp::Adaptor adaptor,
   auto outputPadding =
       Torch::toTorchList(loc, rewriter, adaptor.getOutputPadding().vec());
 
-  // TODO: check the order is matched with what torch needs.
-  auto pads = Padding2d::get(adaptor);
-  auto inputPadding = Torch::toTorchList(
-      loc, rewriter,
-      {pads.hPadding[0], pads.hPadding[1], pads.wPadding[0], pads.hPadding[1]});
+  mlir::Value padValue;
+  auto structPadding = Padding2d::get(adaptor);
+  if (!structPadding.isSymmetric()) {
+    // AtenConvTranspose2dInputOp supports only symmetric padding. This can be
+    // handled by creating a pad operation on the input.
+    newInput = structPadding.createZeroAtenPadOp(rewriter, loc, newInput);
+    padValue = Torch::toTorchList(loc, rewriter, {0, 0});
+  } else {
+    padValue = Torch::toTorchList(
+        loc, rewriter, {structPadding.hPadding[0], structPadding.wPadding[0]});
+  }
 
   return rewriter
       .create<Torch::AtenConvTranspose2dInputOp>(
-          loc, types[0], newInput, newWeights, newBias, stride, inputPadding,
+          loc, types[0], newInput, newWeights, newBias, stride, padValue,
           outputPadding, group, dilation)
       ->getResults();
 }

--- a/lib/Conversion/XTenNNToTorch.cpp
+++ b/lib/Conversion/XTenNNToTorch.cpp
@@ -46,8 +46,13 @@ Type toTorchTensorTypeCast(PatternRewriter &rewriter, ShapedType ty) {
         /*isSigned=*/true);
   }
 
-  return Torch::ValueTensorType::get(ty.getContext(), ty.getShape(),
-                                     elementType);
+  if (!ty.hasRank()) {
+    return Torch::ValueTensorType::get(ty.getContext(), {}, elementType);
+  }
+
+  return Torch::ValueTensorType::get(
+      ty.getContext(), Torch::makeShapeTorchCompatible(ty.getShape()),
+      elementType);
 }
 
 Value toTorchTensorTypeCast(PatternRewriter &rewriter, Value input) {

--- a/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
+++ b/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
@@ -1,0 +1,48 @@
+// RUN: aten-opt --convert-xtennn-to-torch  -split-input-file %s | FileCheck %s
+
+func.func @with_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x72x44xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 1, 1>, array<i64: 1, 1>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x72x44xf32>
+  return %0 : tensor<1x360x72x44xf32>
+}
+
+// -----
+
+func.func @without_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x74x46xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x74x46xf32>
+  return %0 : tensor<1x360x74x46xf32>
+}
+
+// -----
+
+func.func @with_output_padding(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x75x47xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 1, 1>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x75x47xf32>
+  return %0 : tensor<1x360x75x47xf32>
+}
+
+// -----
+
+func.func @with_pad_and_output_pad(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x73x45xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 1, 1>, pad = [array<i64: 1, 1>, array<i64: 1, 1>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x73x45xf32>
+  return %0 : tensor<1x360x73x45xf32>
+}
+
+// -----
+
+func.func @other_configs(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<2x36x84x161xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 3, 3>} : (tensor<2x48x27x52xf32>, tensor<48x36x6x8xf32>, tensor<36xf32>) -> tensor<2x36x84x161xf32>
+  return %0 : tensor<2x36x84x161xf32>
+}
+
+// -----
+
+func.func @other_configs_with_output_shape(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<2x36x82x162xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 1, 1>, array<i64: 0, 0>], stride = array<i64: 3, 3>} : (tensor<2x48x27x52xf32>, tensor<48x36x6x8xf32>, tensor<36xf32>) -> tensor<2x36x82x162xf32>
+  return %0 : tensor<2x36x82x162xf32>
+}
+
+// -----
+
+func.func @dynamic_shape_results(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<?x?x?x?xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 3, 3>} : (tensor<2x48x27x52xf32>, tensor<48x36x6x8xf32>, tensor<36xf32>) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}

--- a/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
+++ b/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
@@ -24,9 +24,7 @@ func.func @with_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x3
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,72,44],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,72,44],f32> -> tensor<1x360x72x44xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x72x44xf32>
@@ -57,9 +55,7 @@ func.func @without_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<48
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,74,46],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,74,46],f32> -> tensor<1x360x74x46xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x74x46xf32>
@@ -90,9 +86,7 @@ func.func @with_output_padding(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,75,47],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,75,47],f32> -> tensor<1x360x75x47xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x75x47xf32>
@@ -123,9 +117,7 @@ func.func @with_pad_and_output_pad(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,73,45],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,73,45],f32> -> tensor<1x360x73x45xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x73x45xf32>
@@ -156,9 +148,7 @@ func.func @other_configs(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8x
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[2,48,27,52],f32>, !torch.vtensor<[48,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,36,84,161],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[2,36,84,161],f32> -> tensor<2x36x84x161xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<2x36x84x161xf32>
@@ -188,10 +178,8 @@ func.func @other_configs_with_output_shape(%arg0: tensor<2x48x27x52xf32>, %arg1:
 // CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
 // CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[2,48,27,52],f32>, !torch.vtensor<[48,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,36,82,162],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[2,36,82,162],f32> -> tensor<2x36x82x162xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<2x36x82x162xf32>
@@ -222,9 +210,76 @@ func.func @dynamic_shape(%arg0: tensor<?x?x27x52xf32>, %arg1: tensor<?x36x6x8xf3
 // CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
 // CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
-// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[?,?,27,52],f32>, !torch.vtensor<[?,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[?,?,?,?],f32>
 // CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[?,?,?,?],f32> -> tensor<?x?x?x?xf32>
 // CHECK-NEXT:          return %[[VAL_22]] : tensor<?x?x?x?xf32>
+
+// -----
+
+func.func @group_more_than_1(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<720xf32>) -> tensor<1x720x72x44xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 2 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 1, 1>, array<i64: 1, 1>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<720xf32>) -> tensor<1x720x72x44xf32>
+  return %0 : tensor<1x720x72x44xf32>
+}
+
+// CHECK-LABEL:   func.func @group_more_than_1(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: tensor<720xf32>) -> tensor<1x720x72x44xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<720xf32> -> !torch.vtensor<[720],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_19:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_18]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[720],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,720,72,44],f32>
+// CHECK-NEXT:          %[[VAL_20:.*]] = torch_c.to_builtin_tensor %[[VAL_19]] : !torch.vtensor<[1,720,72,44],f32> -> tensor<1x720x72x44xf32>
+// CHECK-NEXT:          return %[[VAL_20]] : tensor<1x720x72x44xf32>
+
+// -----
+
+func.func @asymmetric_pad(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<720xf32>) -> tensor<1x720x72x44xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 2 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 1, 0>, array<i64: 1, 0>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<720xf32>) -> tensor<1x720x72x44xf32>
+  return %0 : tensor<1x720x72x44xf32>
+}
+
+// CHECK-LABEL:   func.func @asymmetric_pad(
+// CHECK-SAME:                              %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                              %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                              %[[VAL_2:.*]]: tensor<720xf32>) -> tensor<1x720x72x44xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<720xf32> -> !torch.vtensor<[720],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_21:.*]] = torch.prim.ListConstruct %[[VAL_17]], %[[VAL_18]], %[[VAL_19]], %[[VAL_20]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_22:.*]] = torch.aten.constant_pad_nd %[[VAL_3]], %[[VAL_21]], %[[VAL_16]] : !torch.vtensor<[1,480,36,22],f32>, !torch.list<int>, !torch.int -> !torch.vtensor<[1,480,37,23],f32>
+// CHECK-DAG:           %[[VAL_23:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_24:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_25:.*]] = torch.prim.ListConstruct %[[VAL_23]], %[[VAL_24]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_26:.*]] = torch.aten.conv_transpose2d.input %[[VAL_22]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_25]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,37,23],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[720],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,720,72,44],f32>
+// CHECK-NEXT:          %[[VAL_27:.*]] = torch_c.to_builtin_tensor %[[VAL_26]] : !torch.vtensor<[1,720,72,44],f32> -> tensor<1x720x72x44xf32>
+// CHECK-NEXT:          return %[[VAL_27]] : tensor<1x720x72x44xf32>

--- a/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
+++ b/test/Conversion/XTenNNToTorch/conv_transpose_2d.mlir
@@ -5,12 +5,64 @@ func.func @with_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x3
   return %0 : tensor<1x360x72x44xf32>
 }
 
+// CHECK-LABEL:   func.func @with_output_shape(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: tensor<360xf32>) -> tensor<1x360x72x44xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<360xf32> -> !torch.vtensor<[360],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,72,44],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,72,44],f32> -> tensor<1x360x72x44xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x72x44xf32>
+
 // -----
 
 func.func @without_output_shape(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x74x46xf32> {
   %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x74x46xf32>
   return %0 : tensor<1x360x74x46xf32>
 }
+
+// CHECK-LABEL:   func.func @without_output_shape(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                                    %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                                    %[[VAL_2:.*]]: tensor<360xf32>) -> tensor<1x360x74x46xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<360xf32> -> !torch.vtensor<[360],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,74,46],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,74,46],f32> -> tensor<1x360x74x46xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x74x46xf32>
 
 // -----
 
@@ -19,12 +71,64 @@ func.func @with_output_padding(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480
   return %0 : tensor<1x360x75x47xf32>
 }
 
+// CHECK-LABEL:   func.func @with_output_padding(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                                   %[[VAL_2:.*]]: tensor<360xf32>) -> tensor<1x360x75x47xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<360xf32> -> !torch.vtensor<[360],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,75,47],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,75,47],f32> -> tensor<1x360x75x47xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x75x47xf32>
+
 // -----
 
 func.func @with_pad_and_output_pad(%arg0: tensor<1x480x36x22xf32>, %arg1: tensor<480x360x4x4xf32>, %arg2: tensor<360xf32>) -> tensor<1x360x73x45xf32> {
   %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 1, 1>, pad = [array<i64: 1, 1>, array<i64: 1, 1>], stride = array<i64: 2, 2>} : (tensor<1x480x36x22xf32>, tensor<480x360x4x4xf32>, tensor<360xf32>) -> tensor<1x360x73x45xf32>
   return %0 : tensor<1x360x73x45xf32>
 }
+
+// CHECK-LABEL:   func.func @with_pad_and_output_pad(
+// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x480x36x22xf32>,
+// CHECK-SAME:                                       %[[VAL_1:.*]]: tensor<480x360x4x4xf32>,
+// CHECK-SAME:                                       %[[VAL_2:.*]]: tensor<360xf32>) -> tensor<1x360x73x45xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x480x36x22xf32> -> !torch.vtensor<[1,480,36,22],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<480x360x4x4xf32> -> !torch.vtensor<[480,360,4,4],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<360xf32> -> !torch.vtensor<[360],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 2
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[1,480,36,22],f32>, !torch.vtensor<[480,360,4,4],f32>, !torch.vtensor<[360],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[1,360,73,45],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[1,360,73,45],f32> -> tensor<1x360x73x45xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<1x360x73x45xf32>
 
 // -----
 
@@ -33,6 +137,32 @@ func.func @other_configs(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8x
   return %0 : tensor<2x36x84x161xf32>
 }
 
+// CHECK-LABEL:   func.func @other_configs(
+// CHECK-SAME:                             %[[VAL_0:.*]]: tensor<2x48x27x52xf32>,
+// CHECK-SAME:                             %[[VAL_1:.*]]: tensor<48x36x6x8xf32>,
+// CHECK-SAME:                             %[[VAL_2:.*]]: tensor<36xf32>) -> tensor<2x36x84x161xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<2x48x27x52xf32> -> !torch.vtensor<[2,48,27,52],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<48x36x6x8xf32> -> !torch.vtensor<[48,36,6,8],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<36xf32> -> !torch.vtensor<[36],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[2,48,27,52],f32>, !torch.vtensor<[48,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,36,84,161],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[2,36,84,161],f32> -> tensor<2x36x84x161xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<2x36x84x161xf32>
+
 // -----
 
 func.func @other_configs_with_output_shape(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<2x36x82x162xf32> {
@@ -40,9 +170,61 @@ func.func @other_configs_with_output_shape(%arg0: tensor<2x48x27x52xf32>, %arg1:
   return %0 : tensor<2x36x82x162xf32>
 }
 
+// CHECK-LABEL:   func.func @other_configs_with_output_shape(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<2x48x27x52xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<48x36x6x8xf32>,
+// CHECK-SAME:                                               %[[VAL_2:.*]]: tensor<36xf32>) -> tensor<2x36x82x162xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<2x48x27x52xf32> -> !torch.vtensor<[2,48,27,52],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<48x36x6x8xf32> -> !torch.vtensor<[48,36,6,8],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<36xf32> -> !torch.vtensor<[36],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[2,48,27,52],f32>, !torch.vtensor<[48,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,36,82,162],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[2,36,82,162],f32> -> tensor<2x36x82x162xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<2x36x82x162xf32>
+
 // -----
 
-func.func @dynamic_shape_results(%arg0: tensor<2x48x27x52xf32>, %arg1: tensor<48x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<?x?x?x?xf32> {
-  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 3, 3>} : (tensor<2x48x27x52xf32>, tensor<48x36x6x8xf32>, tensor<36xf32>) -> tensor<?x?x?x?xf32>
+func.func @dynamic_shape(%arg0: tensor<?x?x27x52xf32>, %arg1: tensor<?x36x6x8xf32>, %arg2: tensor<36xf32>) -> tensor<?x?x?x?xf32> {
+  %0 = xten_nn.ConvTranspose %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, group = 1 : i64, output_padding = array<i64: 0, 0>, pad = [array<i64: 0, 0>, array<i64: 0, 0>], stride = array<i64: 3, 3>} : (tensor<?x?x27x52xf32>, tensor<?x36x6x8xf32>, tensor<36xf32>) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
+
+// CHECK-LABEL:   func.func @dynamic_shape(
+// CHECK-SAME:                             %[[VAL_0:.*]]: tensor<?x?x27x52xf32>,
+// CHECK-SAME:                             %[[VAL_1:.*]]: tensor<?x36x6x8xf32>,
+// CHECK-SAME:                             %[[VAL_2:.*]]: tensor<36xf32>) -> tensor<?x?x?x?xf32> attributes {torch.onnx_meta.opset_version = 19 : si64} {
+// CHECK-DAG:           %[[VAL_3:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<?x?x27x52xf32> -> !torch.vtensor<[?,?,27,52],f32>
+// CHECK-DAG:           %[[VAL_4:.*]] = torch_c.from_builtin_tensor %[[VAL_1]] : tensor<?x36x6x8xf32> -> !torch.vtensor<[?,36,6,8],f32>
+// CHECK-DAG:           %[[VAL_5:.*]] = torch_c.from_builtin_tensor %[[VAL_2]] : tensor<36xf32> -> !torch.vtensor<[36],f32>
+// CHECK-DAG:           %[[VAL_6:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_7:.*]] = torch.constant.int 3
+// CHECK-DAG:           %[[VAL_8:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_7]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_9:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_10:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_11:.*]] = torch.prim.ListConstruct %[[VAL_9]], %[[VAL_10]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_12:.*]] = torch.constant.int 1
+// CHECK-DAG:           %[[VAL_13:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_14:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_15:.*]] = torch.prim.ListConstruct %[[VAL_13]], %[[VAL_14]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK-DAG:           %[[VAL_16:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_17:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_18:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_19:.*]] = torch.constant.int 0
+// CHECK-DAG:           %[[VAL_20:.*]] = torch.prim.ListConstruct %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK-NEXT:          %[[VAL_21:.*]] = torch.aten.conv_transpose2d.input %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_8]], %[[VAL_20]], %[[VAL_15]], %[[VAL_12]], %[[VAL_11]] : !torch.vtensor<[?,?,27,52],f32>, !torch.vtensor<[?,36,6,8],f32>, !torch.vtensor<[36],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int, !torch.list<int> -> !torch.vtensor<[?,?,?,?],f32>
+// CHECK-NEXT:          %[[VAL_22:.*]] = torch_c.to_builtin_tensor %[[VAL_21]] : !torch.vtensor<[?,?,?,?],f32> -> tensor<?x?x?x?xf32>
+// CHECK-NEXT:          return %[[VAL_22]] : tensor<?x?x?x?xf32>


### PR DESCRIPTION

- This PR provides xten-nn-to-torch legalization for conv2d transpose operation. The xtenn one doesn't have **output_shape** attribute anymore (like the one for onnx) and it's close to the definition of this operation for torch.aten. Therefore, it only has **output_padding** attribute for padding on the output. Everything is controlled via `output_padding`.
- xten-nn-to-torch also now supports dynamic shape and it was previously crashing on dynamic shapes.