### PR TITLE
Allow xten_nn kernel without results

### DIFF
--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -223,8 +223,14 @@ ParseResult KernelOp::parse(OpAsmParser &p, OperationState &result) {
     return failure();
 
   if (parseKernelArgumentList(p, result.operands) ||
-      p.parseOptionalAttrDict(result.attributes) || p.parseArrow() ||
-      p.parseTypeList(result.types))
+      p.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  // If the op has no results, the `-> type($results)` is absent.
+  if (p.parseOptionalArrow())
+    return success();
+
+  if (p.parseTypeList(result.types))
     return failure();
 
   return success();
@@ -243,8 +249,10 @@ void KernelOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict(getOperation()->getAttrs(), elidedAttrs);
   if (getOperation()->getAttrs().size() > elidedAttrs.size())
     p << ' ';
-  p << "-> ";
-  p << getResultTypes();
+  if (getNumResults()) {
+    p << "-> ";
+    p << getResultTypes();
+  }
 }
 
 #define GET_OP_CLASSES

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -24,6 +24,8 @@ func.func @subgraph_empty(%arg0:  tensor<2xi64>) ->  tensor<2xi64> {
 
 // CHECK-LABEL: kernel
 func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
+    xten_nn.kernel "myKernel" ()
+    // CHECK: xten_nn.kernel "myKernel" ()
     %a = xten_nn.kernel "myKernel" () -> tensor<2xi64>
     // CHECK: xten_nn.kernel "myKernel" () -> tensor<2xi64>
     %b = xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>) -> tensor<2xi64>

--- a/test/Dialect/XTenNN/ops_invalid.mlir
+++ b/test/Dialect/XTenNN/ops_invalid.mlir
@@ -60,3 +60,10 @@ func.func @kernel_missing_name() {
     %b = xten_nn.kernel () -> tensor<2xi64>
     return
 }
+
+// -----
+
+func.func @kernel_missing_result(%arg0: i8, %arg1: i8) {
+    // expected-error@+1 {{expected non-function type}}
+    xten_nn.kernel "myKernel" () ->
+}


### PR DESCRIPTION
Allow to build kernels that have no results to help testing. This is also relevant for kernels on memrefs, where the output buffers will be passed in as output arguments.