### PR TITLE
Don't use StringRef::equals

### DIFF
--- a/lib/Transform/XTenMinimizeLiveTensors.cpp
+++ b/lib/Transform/XTenMinimizeLiveTensors.cpp
@@ -136,7 +136,7 @@ bool isGlobalAvgPool(Operation *op) {
     return false;
 
   auto kernelName = cast<StringAttr>(op->getAttr(attr));
-  return kernelName.strref().equals("GlobalAvgPool2D");
+  return kernelName.strref() == "GlobalAvgPool2D";
 }
 
 bool hasAllGAPInputs(Operation *op) {


### PR DESCRIPTION
It's removed upstream. Needed for bumping LLVM.