### PR TITLE
[FXML-5060] Add instantiation arguments to xten_nn.kernel op

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -265,12 +265,14 @@ def XTenNN_KernelOp : XTenNN_Op<"kernel", []> {
         ```
           %c = xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>) {attr = 4 : i32} -> tensor<2xi64>
           %d:2 = xten_nn.kernel "frob" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
+          %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32} {attr = 4 : i32} -> tensor<2xi64>
         ```
     }];
 
     let arguments = (ins
       Variadic<AnyType>:$arguments,
-      StrAttr:$name
+      StrAttr:$name,
+      OptionalAttr<DictionaryAttr>:$instantiation_args
     );
     let results = (outs Variadic<AnyType>:$results);
 

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -272,11 +272,13 @@ def XTenNN_KernelOp : XTenNN_Op<"kernel", []> {
     let arguments = (ins
       Variadic<AnyType>:$arguments,
       StrAttr:$name,
-      OptionalAttr<DictionaryAttr>:$instantiation_args
+      OptionalAttr<ArrayAttr>:$instantiation_args,
+      OptionalAttr<ArrayAttr>:$instantiation_arg_names
     );
     let results = (outs Variadic<AnyType>:$results);
 
     let hasCustomAssemblyFormat = 1;
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -277,6 +277,17 @@ def XTenNN_KernelOp : XTenNN_Op<"kernel", []> {
     );
     let results = (outs Variadic<AnyType>:$results);
 
+    let builders = [
+      OpBuilder<(ins
+        "::mlir::TypeRange":$results,
+        "::mlir::ValueRange":$arguments,
+        "::llvm::StringRef":$name), [{
+          build($_builder, $_state, results, arguments, name, 
+            ::mlir::ArrayAttr(), ::mlir::ArrayAttr());
+        }]
+      >
+    ];
+
     let hasCustomAssemblyFormat = 1;
     let hasVerifier = 1;
 }

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -10,16 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -222,8 +227,18 @@ ParseResult KernelOp::parse(OpAsmParser &p, OperationState &result) {
   if (p.parseAttribute(name, "name", result.attributes))
     return failure();
 
-  if (parseKernelArgumentList(p, result.operands) ||
-      p.parseOptionalAttrDict(result.attributes))
+  if (parseKernelArgumentList(p, result.operands))
+    return failure();
+
+  if(succeeded(p.parseOptionalKeyword("instantiation_args"))) {
+    NamedAttrList instantiationArgs;
+    if(p.parseOptionalAttrDict(instantiationArgs))
+      return failure();
+    DictionaryAttr dictAttr = DictionaryAttr::get(p.getContext(), instantiationArgs);
+    result.addAttribute("instantiation_args", dictAttr);
+  }
+
+  if(p.parseOptionalAttrDict(result.attributes))
     return failure();
 
   // If the op has no results, the `-> type($results)` is absent.
@@ -245,9 +260,21 @@ void KernelOp::print(OpAsmPrinter &p) {
   p << ' ';
   printKernelArgumentList(p, getOperandTypes(), getOperands());
   p << ' ';
-  SmallVector<StringRef> elidedAttrs = {"name"};
+  auto instantiationArgs = getInstantiationArgs();
+  if(instantiationArgs != std::nullopt && !(instantiationArgs->empty())) {
+    p << "instantiation_args ";
+    p.printOptionalAttrDict(instantiationArgs->getValue());
+    p << ' ';
+  }
+  SmallVector<StringRef> elidedAttrs = {"name", "instantiation_args"};
   p.printOptionalAttrDict(getOperation()->getAttrs(), elidedAttrs);
-  if (getOperation()->getAttrs().size() > elidedAttrs.size())
+  if (llvm::any_of(
+          getOperation()->getAttrs(), [&elidedAttrs](NamedAttribute a) {
+            auto name = a.getName();
+            return llvm::any_of(elidedAttrs, [&name](StringRef elidedName) {
+              return name == elidedName;
+            });
+          }))
     p << ' ';
   if (getNumResults()) {
     p << "-> ";

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -232,17 +232,14 @@ static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
 
   if (failed(p.parseCommaSeparatedList([&p, &names, &values]() {
         std::string name;
-        bool hasName = false;
         if (succeeded(p.parseOptionalString(&name))) {
-          hasName = true;
+            names.push_back(StringAttr::get(p.getContext(), name));
           if (failed(p.parseEqual()))
             return failure();
         }
         Attribute attr;
         auto res = p.parseOptionalAttribute(attr);
         if (res.has_value() && succeeded(*res)) {
-          if (hasName)
-            names.push_back(StringAttr::get(p.getContext(), name));
           values.push_back(attr);
         }
         if (res.has_value() && failed(*res))

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -233,7 +233,7 @@ static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
   if (failed(p.parseCommaSeparatedList([&p, &names, &values]() {
         std::string name;
         if (succeeded(p.parseOptionalString(&name))) {
-            names.push_back(StringAttr::get(p.getContext(), name));
+          names.push_back(StringAttr::get(p.getContext(), name));
           if (failed(p.parseEqual()))
             return failure();
         }

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -10,13 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallVector.h"
+#include "xten/Dialect/XTenNN/IR/XTenNNOps.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/SymbolTable.h"
@@ -24,14 +25,16 @@
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "xten/Dialect/XTenNN/IR/XTenNN.h"
 #include "xten/Dialect/XTenNN/IR/XTenNNBase.h"
-#include "xten/Dialect/XTenNN/IR/XTenNNOps.h"
 #include "xten/Dialect/XTenNN/Interfaces/EnclaveOpInterfaces.h"
+
 #include <cstdint>
 
 using namespace mlir;
@@ -219,6 +222,61 @@ static void printKernelArgumentList(OpAsmPrinter &p, TypeRange types,
   p << ")";
 }
 
+static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
+                                          SmallVector<Attribute> &values,
+                                          SmallVector<Attribute> &names) {
+  if (failed(p.parseLBrace()))
+    return failure();
+
+  if (failed(p.parseCommaSeparatedList([&p, &names, &values]() {
+        std::string name;
+        bool hasName = false;
+        if (succeeded(p.parseOptionalKeywordOrString(&name))) {
+          hasName = true;
+          if (failed(p.parseEqual()))
+            return failure();
+        }
+        Attribute attr;
+        auto res = p.parseOptionalAttribute(attr);
+        if (res.has_value() && succeeded(*res)) {
+          if (hasName)
+            names.push_back(StringAttr::get(p.getContext(), name));
+          values.push_back(attr);
+        }
+        if (res.has_value() && failed(*res))
+          return failure();
+
+        return success();
+      }))) {
+    return failure();
+  }
+
+  if (failed(p.parseRBrace()))
+    return failure();
+
+  return success();
+}
+
+static void
+printKernelInstantiationArgs(OpAsmPrinter &p,
+                             ArrayRef<Attribute> instantiationArgs,
+                             ArrayRef<Attribute> instantiationArgNames) {
+  if (!instantiationArgs.empty()) {
+    p << "instantiation_args {";
+    auto zipped = llvm::zip_longest(instantiationArgNames, instantiationArgs);
+    for (auto iter = zipped.begin(); iter != zipped.end(); ++iter) {
+      if (iter != zipped.begin())
+        p << ", ";
+      auto [name, value] = *iter;
+      if (name)
+        p << *name << " = ";
+      if (value)
+        p.printAttribute(*value);
+    }
+    p << '}';
+  }
+}
+
 // Parse
 //  $name custom<KernelArgumentList>(type($arguments), $arguments) attr-dict
 //  `->` type($results)
@@ -230,15 +288,20 @@ ParseResult KernelOp::parse(OpAsmParser &p, OperationState &result) {
   if (parseKernelArgumentList(p, result.operands))
     return failure();
 
-  if(succeeded(p.parseOptionalKeyword("instantiation_args"))) {
-    NamedAttrList instantiationArgs;
-    if(p.parseOptionalAttrDict(instantiationArgs))
+  if (succeeded(p.parseOptionalKeyword("instantiation_args"))) {
+    SmallVector<Attribute> values;
+    SmallVector<Attribute> names;
+    if (failed(parseKernelInstantiationArgs(p, values, names)))
       return failure();
-    DictionaryAttr dictAttr = DictionaryAttr::get(p.getContext(), instantiationArgs);
-    result.addAttribute("instantiation_args", dictAttr);
+    result.addAttribute("instantiation_args",
+                        ArrayAttr::get(p.getContext(), values));
+    if (!names.empty()) {
+      result.addAttribute("instantiation_arg_names",
+                          ArrayAttr::get(p.getContext(), names));
+    }
   }
 
-  if(p.parseOptionalAttrDict(result.attributes))
+  if (p.parseOptionalAttrDict(result.attributes))
     return failure();
 
   // If the op has no results, the `-> type($results)` is absent.
@@ -261,12 +324,17 @@ void KernelOp::print(OpAsmPrinter &p) {
   printKernelArgumentList(p, getOperandTypes(), getOperands());
   p << ' ';
   auto instantiationArgs = getInstantiationArgs();
-  if(instantiationArgs != std::nullopt && !(instantiationArgs->empty())) {
-    p << "instantiation_args ";
-    p.printOptionalAttrDict(instantiationArgs->getValue());
+  auto instantiationArgNames = getInstantiationArgNames();
+  if (instantiationArgs != std::nullopt) {
+    printKernelInstantiationArgs(p, instantiationArgs->getValue(),
+                                 (instantiationArgNames == std::nullopt)
+                                     ? ArrayRef<Attribute>()
+                                     : instantiationArgNames->getValue());
     p << ' ';
   }
-  SmallVector<StringRef> elidedAttrs = {"name", "instantiation_args"};
+
+  SmallVector<StringRef> elidedAttrs = {"name", "instantiation_args",
+                                        "instantiation_arg_names"};
   p.printOptionalAttrDict(getOperation()->getAttrs(), elidedAttrs);
   if (llvm::any_of(
           getOperation()->getAttrs(), [&elidedAttrs](NamedAttribute a) {
@@ -282,6 +350,19 @@ void KernelOp::print(OpAsmPrinter &p) {
   }
 }
 
+LogicalResult KernelOp::verify() {
+  if (getInstantiationArgNames().has_value()) {
+    if (!getInstantiationArgs().has_value())
+      return emitOpError("cannot have instantiation arg names without instantiation args");
+    if (!(getInstantiationArgNamesAttr().empty() ||
+          getInstantiationArgNamesAttr().size() ==
+              getInstantiationArgsAttr().size()))
+      return emitOpError("instantiation arg names must be either empty or as long as instantiation args");
+  }
+
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "xten/Dialect/XTenNN/IR/XTenNNOps.cpp.inc"
 
@@ -293,9 +374,7 @@ ParseResult SubgraphOp::parse(OpAsmParser &p, OperationState &result) {
   return parseEnclaveOp(p, result);
 }
 
-void SubgraphOp::print(OpAsmPrinter &p) {
-  printEnclaveOp(p, *this);
-}
+void SubgraphOp::print(OpAsmPrinter &p) { printEnclaveOp(p, *this); }
 
 LogicalResult SubgraphOp::verify() {
   Block *optBody = this->getOptionalEnclaveBody();

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -222,9 +222,11 @@ static void printKernelArgumentList(OpAsmPrinter &p, TypeRange types,
   p << ")";
 }
 
+// Parse
+// {((name = )?value, )*((name = )?value)}
 static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
-                                          SmallVector<Attribute> &values,
-                                          SmallVector<Attribute> &names) {
+                                                SmallVector<Attribute> &values,
+                                                SmallVector<Attribute> &names) {
   if (failed(p.parseLBrace()))
     return failure();
 
@@ -257,6 +259,8 @@ static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
   return success();
 }
 
+// Print
+// instantiation_args {((name = )?value, )*((name = )?value)}
 static void
 printKernelInstantiationArgs(OpAsmPrinter &p,
                              ArrayRef<Attribute> instantiationArgs,
@@ -278,7 +282,8 @@ printKernelInstantiationArgs(OpAsmPrinter &p,
 }
 
 // Parse
-//  $name custom<KernelArgumentList>(type($arguments), $arguments) attr-dict
+//  $name custom<KernelArgumentList>(type($arguments), $arguments)
+//  (instantiation_args custom<InstantiationArgs>)? attr-dict
 //  `->` type($results)
 ParseResult KernelOp::parse(OpAsmParser &p, OperationState &result) {
   StringAttr name;
@@ -314,8 +319,9 @@ ParseResult KernelOp::parse(OpAsmParser &p, OperationState &result) {
   return success();
 }
 
-// Parse
-//  $name custom<KernelArgumentList>(type($arguments), $arguments) attr-dict
+// Print
+//  $name custom<KernelArgumentList>(type($arguments), $arguments)
+//  (instantiation_args custom<InstantiationArgs>)? attr-dict
 //  `->` type($results)
 void KernelOp::print(OpAsmPrinter &p) {
   p << ' ';
@@ -353,11 +359,13 @@ void KernelOp::print(OpAsmPrinter &p) {
 LogicalResult KernelOp::verify() {
   if (getInstantiationArgNames().has_value()) {
     if (!getInstantiationArgs().has_value())
-      return emitOpError("cannot have instantiation arg names without instantiation args");
+      return emitOpError(
+          "cannot have instantiation arg names without instantiation args");
     if (!(getInstantiationArgNamesAttr().empty() ||
           getInstantiationArgNamesAttr().size() ==
               getInstantiationArgsAttr().size()))
-      return emitOpError("instantiation arg names must be either empty or as long as instantiation args");
+      return emitOpError("instantiation arg names must be either empty or as "
+                         "long as instantiation args");
   }
 
   return success();

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -223,17 +223,17 @@ static void printKernelArgumentList(OpAsmPrinter &p, TypeRange types,
 }
 
 // Parse
-// {((name = )?value, )*((name = )?value)}
+// [((name = )?value, )*((name = )?value)]
 static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
                                                 SmallVector<Attribute> &values,
                                                 SmallVector<Attribute> &names) {
-  if (failed(p.parseLBrace()))
+  if (failed(p.parseLSquare()))
     return failure();
 
   if (failed(p.parseCommaSeparatedList([&p, &names, &values]() {
         std::string name;
         bool hasName = false;
-        if (succeeded(p.parseOptionalKeywordOrString(&name))) {
+        if (succeeded(p.parseOptionalString(&name))) {
           hasName = true;
           if (failed(p.parseEqual()))
             return failure();
@@ -253,20 +253,20 @@ static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
     return failure();
   }
 
-  if (failed(p.parseRBrace()))
+  if (failed(p.parseRSquare()))
     return failure();
 
   return success();
 }
 
 // Print
-// instantiation_args {((name = )?value, )*((name = )?value)}
+// instantiation_args [((name = )?value, )*((name = )?value)]
 static void
 printKernelInstantiationArgs(OpAsmPrinter &p,
                              ArrayRef<Attribute> instantiationArgs,
                              ArrayRef<Attribute> instantiationArgNames) {
   if (!instantiationArgs.empty()) {
-    p << "instantiation_args {";
+    p << "instantiation_args [";
     auto zipped = llvm::zip_longest(instantiationArgNames, instantiationArgs);
     for (auto iter = zipped.begin(); iter != zipped.end(); ++iter) {
       if (iter != zipped.begin())
@@ -277,7 +277,7 @@ printKernelInstantiationArgs(OpAsmPrinter &p,
       if (value)
         p.printAttribute(*value);
     }
-    p << '}';
+    p << ']';
   }
 }
 
@@ -358,14 +358,16 @@ void KernelOp::print(OpAsmPrinter &p) {
 
 LogicalResult KernelOp::verify() {
   if (getInstantiationArgNames().has_value()) {
-    if (!getInstantiationArgs().has_value())
+    if (!getInstantiationArgs().has_value()) {
       return emitOpError(
           "cannot have instantiation arg names without instantiation args");
+    }
     if (!(getInstantiationArgNamesAttr().empty() ||
           getInstantiationArgNamesAttr().size() ==
-              getInstantiationArgsAttr().size()))
+              getInstantiationArgsAttr().size())) {
       return emitOpError("instantiation arg names must be either empty or as "
                          "long as instantiation args");
+    }
   }
 
   return success();

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -34,6 +34,8 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>) {attr = 4 : i32} -> tensor<2xi64>
     %d:2 = xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
+    %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -35,11 +35,11 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     %d:2 = xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
     %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {"N" = 42 : i32, "idx" = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     %f = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56} {attr = 4 : i32} -> tensor<2xi64>
-    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56} {attr = 4 : i32} -> tensor<2xi64>
+    %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56, 1.0} {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i64, 56 : i64, 1.000000e+00 : f64} {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -38,6 +38,8 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     %f = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
+    %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56} {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56} {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -34,12 +34,12 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>) {attr = 4 : i32} -> tensor<2xi64>
     %d:2 = xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
-    %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {"N" = 42 : i32, "idx" = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    %f = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
-    %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42, 56, 1.0} {attr = 4 : i32} -> tensor<2xi64>
-    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i64, 56 : i64, 1.000000e+00 : f64} {attr = 4 : i32} -> tensor<2xi64>
+    %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args ["N" = 42 : i32, "idx" = 56 : index] {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args ["N" = 42 : i32, "idx" = 56 : index] {attr = 4 : i32} -> tensor<2xi64>
+    %f = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42 : i32, 56 : index] {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42 : i32, 56 : index] {attr = 4 : i32} -> tensor<2xi64>
+    %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42, 56, 1.0] {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42 : i64, 56 : i64, 1.000000e+00 : f64] {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -36,6 +36,8 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     // CHECK: xten_nn.kernel "myKernel" (%arg0 : tensor<2xi64>, %arg1 : tensor<4xi64>) -> tensor<2xi64>, tensor<1xi64>
     %e = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {N = 42 : i32, idx = 56 : index} {attr = 4 : i32} -> tensor<2xi64>
+    %f = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args {42 : i32, 56 : index} {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 

--- a/test/Dialect/XTenNN/ops_invalid.mlir
+++ b/test/Dialect/XTenNN/ops_invalid.mlir
@@ -72,7 +72,7 @@ func.func @kernel_missing_result(%arg0: i8, %arg1: i8) {
 
 func.func @kernel_instantiation_list_different_length(%arg0: i8, %arg1: i8) {
     // expected-error@+1 {{instantiation arg names must be either empty or as long as instantiation args}}
-    %x = xten_nn.kernel "myKernel" () instantiation_args {N = 42 : i32, 51 : index} -> i32
+    %x = xten_nn.kernel "myKernel" () instantiation_args ["N" = 42 : i32, 51 : index] -> i32
     return
 }
 
@@ -83,6 +83,15 @@ func.func @kernel_instantiation_list_non_empty(%arg0: i8, %arg1: i8) {
     %x = xten_nn.kernel "myKernel" () {instantiation_arg_names = ["N"]} -> i32
     return
 }
+
+// -----
+
+func.func @kernel_instantiation_list_non_quoted(%arg0: i8, %arg1: i8) {
+    // expected-error@+1 {{expected ']'}}
+    %x = xten_nn.kernel "myKernel" () instantiation_args [N = 42 : i32] -> i32
+    return
+}
+
 
 // -----
 

--- a/test/Dialect/XTenNN/ops_invalid.mlir
+++ b/test/Dialect/XTenNN/ops_invalid.mlir
@@ -70,6 +70,22 @@ func.func @kernel_missing_result(%arg0: i8, %arg1: i8) {
 
 // -----
 
+func.func @kernel_instantiation_list_different_length(%arg0: i8, %arg1: i8) {
+    // expected-error@+1 {{instantiation arg names must be either empty or as long as instantiation args}}
+    %x = xten_nn.kernel "myKernel" () instantiation_args {N = 42 : i32, 51 : index} -> i32
+    return
+}
+
+// -----
+
+func.func @kernel_instantiation_list_non_empty(%arg0: i8, %arg1: i8) {
+    // expected-error@+1 {{cannot have instantiation arg names without instantiation args}}
+    %x = xten_nn.kernel "myKernel" () {instantiation_arg_names = ["N"]} -> i32
+    return
+}
+
+// -----
+
 func.func @topk_wrong_output_shape(%arg0: tensor<10x10xf32>) {
     %k = arith.constant 7 : i64
     // expected-error@+2 {{failed to infer returned types}}


### PR DESCRIPTION
This adds a new `instantiation_args` attribute to the `xten_nn.kernel` op, to represent instantiation arguments of templated kernels.
Optionally, the `instantiation_arg_names` attribute can be used to give names to the instantiation arguments. If there are names, then there must be as many names as arguments.

Instantiation arguments are integrated in the custom assembly as follows:
```
xten_nn.kernel "name" () instantiation_args ["N" = 42 : i32, "P" = 1 : i1]
xten_nn.kernel "name" () instantiation_args [42 : i32, 1 : i1]
xten_nn.kernel "name" () instantiation_args [2, 5]
```
