### PR TITLE
[FXML-5060] Kernel op: Amend instantiation args parser to support unnamed strings

### DIFF
--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -233,9 +233,12 @@ static ParseResult parseKernelInstantiationArgs(OpAsmParser &p,
   if (failed(p.parseCommaSeparatedList([&p, &names, &values]() {
         std::string name;
         if (succeeded(p.parseOptionalString(&name))) {
+          if (failed(p.parseOptionalEqual())) {
+            // This is an unnamed string parameter (e.g. class name).
+            values.push_back(StringAttr::get(p.getContext(), name));
+            return success();
+          }
           names.push_back(StringAttr::get(p.getContext(), name));
-          if (failed(p.parseEqual()))
-            return failure();
         }
         Attribute attr;
         auto res = p.parseOptionalAttribute(attr);

--- a/test/Dialect/XTenNN/ops.mlir
+++ b/test/Dialect/XTenNN/ops.mlir
@@ -40,6 +40,10 @@ func.func @kernel(%arg0: tensor<2xi64>, %arg1 : tensor<4xi64>) {
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42 : i32, 56 : index] {attr = 4 : i32} -> tensor<2xi64>
     %g = xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42, 56, 1.0] {attr = 4 : i32} -> tensor<2xi64>
     // CHECK: xten_nn.kernel "matmul" (%arg0 : tensor<2xi64>) instantiation_args [42 : i64, 56 : i64, 1.000000e+00 : f64] {attr = 4 : i32} -> tensor<2xi64>
+    %h = xten_nn.kernel "readInput" (%arg0 : tensor<2xi64>) instantiation_args ["type" = "double", "length" = 42 : i64] {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "readInput" (%arg0 : tensor<2xi64>) instantiation_args ["type" = "double", "length" = 42 : i64] {attr = 4 : i32} -> tensor<2xi64>
+    %i = xten_nn.kernel "readInput" (%arg0 : tensor<2xi64>) instantiation_args ["double", 42 : i64] {attr = 4 : i32} -> tensor<2xi64>
+    // CHECK: xten_nn.kernel "readInput" (%arg0 : tensor<2xi64>) instantiation_args ["double", 42 : i64] {attr = 4 : i32} -> tensor<2xi64>
     return
 }
 


### PR DESCRIPTION
This is the tiny bit that was missing in [this PR](https://github.com/Xilinx/mlir-xten/pull/94), to also accept unnamed string parameters.

This enables the op's parser to parse its printer's own output in this case as well :)