### PR TITLE
Use the same implementation for quantize/dequantize as onnx if the quantization zero point is not zero.

### DIFF
--- a/lib/Conversion/XTenNNToTosa.cpp
+++ b/lib/Conversion/XTenNNToTosa.cpp
@@ -24,26 +24,20 @@ namespace {
 /// Convert the quantized integer type from signed to a signless version that
 /// matches TOSA.
 ///
-/// TOSA currently supports i8, i16, i32 tensors types. Here we convert the
-/// arbitrary signed type from the XTenNN QDQ operators to one that can be
-/// represented in TOSA.
-/// @TODO: once TOSA moves from signless to signed integers with arbitrary
-/// bit width we no longer need the type conversion.
+/// tosa-mlir supports arbitrary bitwidth, but for historic reasons signless is
+/// used instead of signed
 ///
 ///\param tensorType signed integer tensor type.
 ///\return TensorType new storage type for the \p tensorType.
 TensorType getNewStorageType(TensorType tensorType) {
-  assert(tensorType.getElementType().isSignlessInteger() &&
+  assert(tensorType.getElementType().isInteger() &&
          "quantization should only work with integers");
-  unsigned int integerBitwidth = tensorType.getElementTypeBitWidth();
-  unsigned int storageBitWidth = 32;
-  if (integerBitwidth <= 8) {
-    storageBitWidth = 8;
-  } else if (integerBitwidth <= 16) {
-    storageBitWidth = 16;
-  }
   return tensorType.cloneWith(
-      {}, IntegerType::get(tensorType.getContext(), storageBitWidth));
+      {}, IntegerType::get(tensorType.getContext(),
+                           tensorType.getElementTypeBitWidth(),
+                           (tensorType.getElementType().isUnsignedInteger())
+                               ? IntegerType::Unsigned
+                               : IntegerType::Signless));
 }
 
 RankedTensorType createSplatType(int64_t rank, Type elementType) {
@@ -56,29 +50,6 @@ RankedTensorType createSplatType(int64_t rank, Type elementType) {
     tmpShape.emplace_back(1);
   }
   return RankedTensorType::get(tmpShape, elementType);
-}
-
-/// Hold min and max values of an Integer type
-struct IntegerMinMax {
-  int64_t min = std::numeric_limits<int64_t>::min();
-  int64_t max = std::numeric_limits<int64_t>::max();
-};
-
-/// Calculate the limits of the given Tensor Element Type.
-///
-///\param type the tensor type we are inspecting for the element type.
-///\return IntegerMinMax for the element integer type of the tensor \p type. If
-/// the element type is not a IntegerType then return the min and max of int64_t
-IntegerMinMax calculateMinMaxOfElementType(TensorType type) {
-  IntegerType intType = dyn_cast<IntegerType>(type.getElementType());
-  if (!intType) {
-    return IntegerMinMax{};
-  }
-  auto minValue =
-      llvm::APSInt::getMinValue(intType.getWidth(), type.isUnsignedInteger());
-  auto maxValue =
-      llvm::APSInt::getMaxValue(intType.getWidth(), type.isUnsignedInteger());
-  return IntegerMinMax{minValue.getSExtValue(), maxValue.getSExtValue()};
 }
 
 namespace {
@@ -104,15 +75,9 @@ public:
   LogicalResult matchAndRewrite(amd::xten_nn::QuantizeOp quantizeOp,
                                 PatternRewriter &rewriter) const override {
     // The QDQ operations only work on tensors, if they are not, then the
-    // verifiers should find the error. At the moment, only signless tensors
-    // are supported.
+    // verifiers should find the error.
     const auto outputType =
         cast<TensorType>(quantizeOp->getResult(0).getType());
-    if (!outputType.getElementType().isSignlessInteger()) {
-      return rewriter.notifyMatchFailure(
-          quantizeOp.getLoc(),
-          "only signless integer tensor types are supported.");
-    }
     const auto inputType =
         cast<TensorType>(quantizeOp->getOperand(0).getType());
     const auto inputElementType = inputType.getElementType();
@@ -133,43 +98,38 @@ public:
         quantizeOp.getLoc(), inputType, quantizeOp->getOperand(0),
         constOp->getResult(0), rewriter.getI8IntegerAttr(0));
 
-    const auto constAddType =
-        createSplatType(inputType.getRank(), outputType.getElementType());
-    auto constAddOp = rewriter.create<tosa::ConstOp>(
-        quantizeOp.getLoc(), constAddType,
-        DenseIntElementsAttr::get(constAddType, {quantizeOp.getZeroPoint()}));
-    auto constAddCastOp = rewriter.create<tosa::CastOp>(
-        quantizeOp.getLoc(), inputType, constAddOp.getResult());
-    auto zeroPointAdd = rewriter.create<tosa::AddOp>(
-        quantizeOp.getLoc(), inputType, mulOp.getResult(),
-        constAddCastOp.getResult());
+    mlir::Value castFrom = mulOp->getResult(0);
+    if (!quantizeOp.getZeroPoint().isZero()) {
+      // Do the zero_point calculation on int32 to match the reference
+      // implementation:
+      // https://github.com/onnx/onnx/blob/3d5acaf3e23ae8db7ac01b8cfedb17b8817121f4/onnx/reference/ops/op_quantize_linear.py#L177
+      const auto int32InputType =
+          inputType.cloneWith({}, rewriter.getI32Type());
+      auto castToint32Op = rewriter.create<tosa::CastOp>(
+          quantizeOp->getLoc(), int32InputType, mulOp.getResult());
 
-    // TOSA only supports signed integers of i8, i16 or i32 here we convert our
-    // si<?> to this types and add a clamp to mimic arbitrary bit width.
-    TensorType newIntegerStorageType = getNewStorageType(outputType);
-    // Cast from fp32 -> i<Bitwidth> where bit width is the supported storage
-    // bit width. Either i8, i16 or i32
-    auto castOp = rewriter.create<tosa::CastOp>(quantizeOp->getLoc(),
-                                                newIntegerStorageType,
-                                                zeroPointAdd->getResult(0));
-
-    // Find the max and min of the signed integer type.
-    IntegerMinMax intLimits = calculateMinMaxOfElementType(outputType);
-
-    // Clamp the integer to the min and max we calculated for this custom
-    // bit width
-    auto clampOp = rewriter.createOrFold<tosa::ClampOp>(
-        quantizeOp->getLoc(), newIntegerStorageType, castOp->getResult(0),
-        rewriter.getI64IntegerAttr(intLimits.min),
-        rewriter.getI64IntegerAttr(intLimits.max),
-        rewriter.getF32FloatAttr((float)intLimits.min),
-        rewriter.getF32FloatAttr((float)intLimits.max));
+      const auto constAddType =
+          createSplatType(inputType.getRank(), outputType.getElementType());
+      auto constAddOp = rewriter.create<tosa::ConstOp>(
+          quantizeOp.getLoc(), constAddType,
+          DenseIntElementsAttr::get(constAddType, {quantizeOp.getZeroPoint()}));
+      auto constAddCastOp = rewriter.create<tosa::CastOp>(
+          quantizeOp.getLoc(), int32InputType, constAddOp.getResult());
+      auto zeroPointAdd = rewriter.create<tosa::AddOp>(
+          quantizeOp.getLoc(), int32InputType, castToint32Op.getResult(),
+          constAddCastOp.getResult());
+      castFrom = zeroPointAdd->getResult(0);
+    }
+    const TensorType newIntegerStorageType = getNewStorageType(outputType);
+    auto castOp = rewriter.create<tosa::CastOp>(
+        quantizeOp->getLoc(), newIntegerStorageType, castFrom);
 
     // Use an unrealized conversion cast to match the original output type.
     // We convert I back to SI because TOSA does not support the SI type
     // explicitly.
     auto unrealizedCast = rewriter.create<UnrealizedConversionCastOp>(
-        quantizeOp->getLoc(), quantizeOp->getResult(0).getType(), clampOp);
+        quantizeOp->getLoc(), quantizeOp->getResult(0).getType(),
+        castOp->getResult(0));
 
     // Replace the original op with the new decomposition
     rewriter.replaceOp(quantizeOp, {unrealizedCast.getResult(0)});
@@ -185,17 +145,11 @@ public:
   LogicalResult matchAndRewrite(amd::xten_nn::DequantizeOp dequantizeOp,
                                 PatternRewriter &rewriter) const override {
     // The QDQ operations only work on tensors, if they are not, then the
-    // verifiers should find the error. At the moment, only signless tensors
-    // are supported.
+    // verifiers should find the error.
     const auto resultElementType =
         dequantizeOp.getResult().getType().getElementType();
     const auto inputType =
         cast<TensorType>(dequantizeOp->getOperand(0).getType());
-    if (!inputType.getElementType().isSignlessInteger()) {
-      return rewriter.notifyMatchFailure(
-          dequantizeOp.getLoc(),
-          "only signless integer tensor types are supported.");
-    }
 
     TensorType newIntegerStorageType = getNewStorageType(inputType);
     // We need to convert from si<> to i8, i16 or i32 depending on the input
@@ -204,7 +158,6 @@ public:
         dequantizeOp.getLoc(), newIntegerStorageType,
         dequantizeOp->getOperand(0));
 
-    // We can then cast from i<8,16,32> -> fp
     auto castOp = rewriter.create<tosa::CastOp>(
         dequantizeOp->getLoc(), dequantizeOp->getResult(0).getType(),
         unrealizedCast.getResult(0));

--- a/lib/Conversion/XTenNNToTosa.cpp
+++ b/lib/Conversion/XTenNNToTosa.cpp
@@ -110,15 +110,15 @@ public:
 
       const auto constAddType =
           createSplatType(inputType.getRank(), outputType.getElementType());
-      auto constAddOp = rewriter.create<tosa::ConstOp>(
+      auto zeroPointConstOp = rewriter.create<tosa::ConstOp>(
           quantizeOp.getLoc(), constAddType,
           DenseIntElementsAttr::get(constAddType, {quantizeOp.getZeroPoint()}));
-      auto constAddCastOp = rewriter.create<tosa::CastOp>(
-          quantizeOp.getLoc(), int32InputType, constAddOp.getResult());
-      auto zeroPointAdd = rewriter.create<tosa::AddOp>(
+      auto zeroPointCastOp = rewriter.create<tosa::CastOp>(
+          quantizeOp.getLoc(), int32InputType, zeroPointConstOp.getResult());
+      auto zeroPointAddOp = rewriter.create<tosa::AddOp>(
           quantizeOp.getLoc(), int32InputType, castToint32Op.getResult(),
-          constAddCastOp.getResult());
-      castFrom = zeroPointAdd->getResult(0);
+          zeroPointCastOp.getResult());
+      castFrom = zeroPointAddOp->getResult(0);
     }
     const TensorType newIntegerStorageType = getNewStorageType(outputType);
     auto castOp = rewriter.create<tosa::CastOp>(
@@ -165,13 +165,13 @@ public:
     // Do the zero_point sub on the float type to to avoid underflows
     const auto constSubType =
         createSplatType(inputType.getRank(), inputType.getElementType());
-    auto constSubOp = rewriter.create<tosa::ConstOp>(
+    auto zeroPointConstOp = rewriter.create<tosa::ConstOp>(
         dequantizeOp.getLoc(), constSubType,
         DenseIntElementsAttr::get(constSubType, {dequantizeOp.getZeroPoint()}));
     auto constSubCastOp = rewriter.create<tosa::CastOp>(
         dequantizeOp.getLoc(), dequantizeOp.getResult().getType(),
-        constSubOp.getResult());
-    auto zeroPointSub = rewriter.create<tosa::SubOp>(
+        zeroPointConstOp.getResult());
+    auto zeroPointSubOp = rewriter.create<tosa::SubOp>(
         dequantizeOp.getLoc(), dequantizeOp.getResult().getType(),
         castOp.getResult(), constSubCastOp.getResult());
 
@@ -188,7 +188,7 @@ public:
     // Replace the dequantize op with the new operations we just created.
     rewriter.replaceOpWithNewOp<tosa::MulOp>(
         dequantizeOp, dequantizeOp->getResult(0).getType(),
-        zeroPointSub->getResult(0), constOp->getResult(0),
+        zeroPointSubOp->getResult(0), constOp->getResult(0),
         rewriter.getI8IntegerAttr(0));
     return success();
   }

--- a/test/Conversion/XTenNNToTosa/quantization.mlir
+++ b/test/Conversion/XTenNNToTosa/quantization.mlir
@@ -63,6 +63,7 @@ module attributes{} {
 // --
 
 module attributes{} {
+// COM: tosa does not support casts from/to unsigned, but tosa-mlir does as extension    
 // CHECK-LABEL:    func.func @explicit_case_bf16_to_uint16
 // CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16> {
 // CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>

--- a/test/Conversion/XTenNNToTosa/quantization.mlir
+++ b/test/Conversion/XTenNNToTosa/quantization.mlir
@@ -17,14 +17,16 @@ module attributes{} {
 // CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
 // CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.000000e+00> : tensor<1x3x4x4xf32>}> : () -> tensor<1x3x4x4xf32>
-// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK:             [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_2_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK:             [[VAR_4_:%.+]] = tosa.add [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
-// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
-// CHECK:             [[VAR_6_:%.+]] = tosa.cast [[VAR_5_]] : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
-// CHECK:             [[VAR_7_:%.+]] = tosa.sub [[VAR_6_]], [[VAR_1_]] : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
-// CHECK:             [[VAR_8_:%.+]] = tosa.mul [[VAR_7_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK:             return [[VAR_8_]] : tensor<1x3x4x4xf32>
+// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1> : tensor<1x3x4x4xi32>}> : () -> tensor<1x3x4x4xi32>
+// CHECK-DAG:         [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             [[VAR_4_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_2_]] : (tensor<1x3x4x4xi32>, tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_8_:%.+]] = tosa.cast [[VAR_6_]] : (tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi8>
+// CHECK:             [[VAR_9_:%.+]] = tosa.cast [[VAR_8_]] : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_10_:%.+]] = tosa.sub [[VAR_9_]], [[VAR_1_]] : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_11_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return [[VAR_11_]] : tensor<1x3x4x4xf32>
 // CHECK:           }
     func.func @explicit_case(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
         %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xf32>) {scale = 3.125000e-02 : f32, zero_point = 1 : i8} -> tensor<1x3x4x4xi8>
@@ -40,14 +42,16 @@ module attributes{} {
 // CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16> {
 // CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
 // CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.000000e+00> : tensor<1x3x4x4xbf16>}> : () -> tensor<1x3x4x4xbf16>
-// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
-// CHECK:             [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_2_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
-// CHECK:             [[VAR_4_:%.+]] = tosa.add [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x4x4xbf16>, tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16>
-// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xi8>
-// CHECK:             [[VAR_6_:%.+]] = tosa.cast [[VAR_5_]] : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xbf16>
-// CHECK:             [[VAR_7_:%.+]] = tosa.sub [[VAR_6_]], [[VAR_1_]] : (tensor<1x3x4x4xbf16>, tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16>
-// CHECK:             [[VAR_8_:%.+]] = tosa.mul [[VAR_7_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
-// CHECK:             return [[VAR_8_]] : tensor<1x3x4x4xbf16>
+// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1> : tensor<1x3x4x4xi32>}> : () -> tensor<1x3x4x4xi32>
+// CHECK-DAG:         [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
+// CHECK:             [[VAR_4_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_2_]] : (tensor<1x3x4x4xi32>, tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_8_:%.+]] = tosa.cast [[VAR_6_]] : (tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi8>
+// CHECK:             [[VAR_9_:%.+]] = tosa.cast [[VAR_8_]] : (tensor<1x3x4x4xi8>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_10_:%.+]] = tosa.sub [[VAR_9_]], [[VAR_1_]] : (tensor<1x3x4x4xbf16>, tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_11_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             return [[VAR_11_]] : tensor<1x3x4x4xbf16>
 // CHECK:           }
     func.func @explicit_case_bf16(%arg0: tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16> {
         %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xbf16>) {scale = 3.125000e-02 : f32, zero_point = 1 : i8} -> tensor<1x3x4x4xi8>
@@ -59,16 +63,41 @@ module attributes{} {
 // --
 
 module attributes{} {
-// CHECK-LABEL:     func.func @small_tensors(
-// CHECK-SAME:                               %[[VAL_0:.*]]: tensor<2x3xf32>) -> tensor<2x3xf32> {
-// CHECK-DAG:             %[[VAL_1:.*]] = "tosa.const"() <{value = dense<1.250000e-01> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
-// CHECK-DAG:             %[[VAL_2:.*]] = "tosa.const"() <{value = dense<8.000000e+00> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
-// CHECK-DAG:             %[[VAL_3:.*]] = tosa.mul %[[VAL_0]], %[[VAL_1]] {shift = 0 : i8} : (tensor<2x3xf32>, tensor<1x1xf32>) -> tensor<2x3xf32>
-// CHECK-DAG:             %[[VAL_4:.*]] = tosa.cast %[[VAL_3]] : (tensor<2x3xf32>) -> tensor<2x3xi8>
-// CHECK-DAG:             %[[VAL_5:.*]] = tosa.clamp %[[VAL_4]] {max_fp = 7.000000e+00 : f32, max_int = 7 : i64, min_fp = -8.000000e+00 : f32, min_int = -8 : i64} : (tensor<2x3xi8>) -> tensor<2x3xi8>
-// CHECK-DAG:             %[[VAL_6:.*]] = tosa.cast %[[VAL_5]] : (tensor<2x3xi8>) -> tensor<2x3xf32>
-// CHECK-DAG:             %[[VAL_7:.*]] = tosa.mul %[[VAL_6]], %[[VAL_2]] {shift = 0 : i8} : (tensor<2x3xf32>, tensor<1x1xf32>) -> tensor<2x3xf32>
-// CHECK-DAG:             return %[[VAL_7]] : tensor<2x3xf32>
+// CHECK-LABEL:    func.func @explicit_case_bf16_to_uint16
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16> {
+// CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
+// CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.000000e+00> : tensor<1x3x4x4xbf16>}> : () -> tensor<1x3x4x4xbf16>
+// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1> : tensor<1x3x4x4xi32>}> : () -> tensor<1x3x4x4xi32>
+// CHECK-DAG:         [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
+// CHECK:             [[VAR_4_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_2_]] : (tensor<1x3x4x4xi32>, tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_8_:%.+]] = tosa.cast [[VAR_6_]] : (tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xui16>
+// CHECK:             [[VAR_9_:%.+]] = tosa.cast [[VAR_8_]] : (tensor<1x3x4x4xui16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_10_:%.+]] = tosa.sub [[VAR_9_]], [[VAR_1_]] : (tensor<1x3x4x4xbf16>, tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             [[VAR_11_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x4x4xbf16>
+// CHECK:             return [[VAR_11_]] : tensor<1x3x4x4xbf16>
+// CHECK:           }
+    func.func @explicit_case_bf16_to_uint16(%arg0: tensor<1x3x4x4xbf16>) -> tensor<1x3x4x4xbf16> {
+        %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xbf16>) {scale = 3.125000e-02 : f32, zero_point = 1 : ui16} -> tensor<1x3x4x4xui16>
+        %1 = xten_nn.dequantize(%0 : tensor<1x3x4x4xui16>) {scale = 3.125000e-02 : f32, zero_point = 1 : ui16} -> tensor<1x3x4x4xbf16>
+        return %1 : tensor<1x3x4x4xbf16>
+    }
+}
+
+// --
+
+module attributes{} {
+// CHECK-LABEL:    func.func @small_tensors
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<2x3xf32>) -> tensor<2x3xf32> {
+// CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<8.000000e+00> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
+// CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.250000e-01> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
+// CHECK:             [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<2x3xf32>, tensor<1x1xf32>) -> tensor<2x3xf32>
+// CHECK:             [[VAR_3_:%.+]] = tosa.cast [[VAR_2_]] : (tensor<2x3xf32>) -> tensor<2x3xi4>
+// CHECK:             [[VAR_4_:%.+]] = tosa.cast [[VAR_3_]] : (tensor<2x3xi4>) -> tensor<2x3xf32>
+// CHECK:             [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<2x3xf32>, tensor<1x1xf32>) -> tensor<2x3xf32>
+// CHECK:             return [[VAR_5_]] : tensor<2x3xf32>
+// CHECK:          }
     func.func @small_tensors(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
         %0 = xten_nn.quantize(%arg0 : tensor<2x3xf32>) {scale = 8.0 : f32, shift = 3 : si32, zero_point = 0 : i4} -> tensor<2x3xi4>
         %1 = xten_nn.dequantize(%0 : tensor<2x3xi4>) {scale = 8.0 : f32, shift = 3 : si32, zero_point = 0 : i4} -> tensor<2x3xf32>
@@ -79,12 +108,13 @@ module attributes{} {
 // --
 
 module attributes{} {
-// CHECK-LABEL:     func.func @quantize_case(
-// CHECK-SAME:                               %[[VAL_0:.*]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8> {
-// CHECK-DAG:             %[[VAL_1:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:             %[[VAL_2:.*]] = tosa.mul %[[VAL_0]], %[[VAL_1]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             %[[VAL_3:.*]] = tosa.cast %[[VAL_2]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
-// CHECK-DAG:             return %[[VAL_3]] : tensor<1x3x4x4xi8>
+// CHECK-LABEL:    func.func @quantize_case
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8> {
+// CHECK:             [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_2_:%.+]] = tosa.cast [[VAR_1_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8>
+// CHECK:             return [[VAR_2_]] : tensor<1x3x4x4xi8>
+// CHECK:           }
     func.func @quantize_case(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi8> {
         %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xf32>) {scale = 3.125000e-02 : f32, shift = -5 : si32, zero_point = 0 : i8} -> tensor<1x3x4x4xi8>
         return %0 : tensor<1x3x4x4xi8>
@@ -109,15 +139,16 @@ module attributes{} {
 // --
 
 module attributes{} {
-// CHECK-LABEL:     func.func @i16_case(
-// CHECK-SAME:                          %[[VAL_0:.*]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
-// CHECK-DAG:             %[[VAL_1:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:             %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:             %[[VAL_3:.*]] = tosa.mul %[[VAL_0]], %[[VAL_1]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             %[[VAL_4:.*]] = tosa.cast %[[VAL_3]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi16>
-// CHECK-DAG:             %[[VAL_5:.*]] = tosa.cast %[[VAL_4]] : (tensor<1x3x4x4xi16>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             %[[VAL_6:.*]] = tosa.mul %[[VAL_5]], %[[VAL_2]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             return %[[VAL_6]] : tensor<1x3x4x4xf32>
+// CHECK-LABEL:    func.func @i16_case
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
+// CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_3_:%.+]] = tosa.cast [[VAR_2_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi16>
+// CHECK:             [[VAR_4_:%.+]] = tosa.cast [[VAR_3_]] : (tensor<1x3x4x4xi16>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return [[VAR_5_]] : tensor<1x3x4x4xf32>
+// CHECK:           }
     func.func @i16_case(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
         %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xf32>) {scale = 3.125000e-02 : f32, shift = -5 : si32, zero_point = 0 : i16} -> tensor<1x3x4x4xi16>
         %1 = xten_nn.dequantize(%0 : tensor<1x3x4x4xi16>) {scale = 3.125000e-02 : f32, shift = -5 : si32, zero_point = 0 : i16} -> tensor<1x3x4x4xf32>
@@ -125,19 +156,46 @@ module attributes{} {
     }
 }
 
+
+// --
+
+
+module attributes{} {
+// CHECK-LABEL:    func.func @i16_case_zero_point
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
+// CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.000000e+00> : tensor<1x3x4x4xf32>}> : () -> tensor<1x3x4x4xf32>
+// CHECK-DAG:         [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1> : tensor<1x3x4x4xi32>}> : () -> tensor<1x3x4x4xi32>
+// CHECK-DAG:         [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             [[VAR_4_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_2_]] : (tensor<1x3x4x4xi32>, tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi32>
+// CHECK:             [[VAR_7_:%.+]] = tosa.cast [[VAR_6_]] : (tensor<1x3x4x4xi32>) -> tensor<1x3x4x4xi16>
+// CHECK:             [[VAR_8_:%.+]] = tosa.cast [[VAR_7_]] : (tensor<1x3x4x4xi16>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_9_:%.+]] = tosa.sub [[VAR_8_]], [[VAR_1_]] : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_10_:%.+]] = tosa.mul [[VAR_9_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return [[VAR_10_]] : tensor<1x3x4x4xf32>
+// CHECK:           }
+    func.func @i16_case_zero_point(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
+        %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xf32>) {scale = 3.125000e-02 : f32, zero_point = 1 : i16} -> tensor<1x3x4x4xi16>
+        %1 = xten_nn.dequantize(%0 : tensor<1x3x4x4xi16>) {scale = 3.125000e-02 : f32, zero_point = 1 : i16} -> tensor<1x3x4x4xf32>
+        return %1 : tensor<1x3x4x4xf32>
+    }
+}
+
 // --
 
 module attributes{} {
-// CHECK-LABEL:     func.func @i12_case(
-// CHECK-SAME:                          %[[VAL_0:.*]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
-// CHECK-DAG:             %[[VAL_1:.*]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:             %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:             %[[VAL_3:.*]] = tosa.mul %[[VAL_0]], %[[VAL_1]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             %[[VAL_4:.*]] = tosa.cast %[[VAL_3]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi16>
-// CHECK-DAG:             %[[VAL_5:.*]] = tosa.clamp %[[VAL_4]] {max_fp = 2.047000e+03 : f32, max_int = 2047 : i64, min_fp = -2.048000e+03 : f32, min_int = -2048 : i64} : (tensor<1x3x4x4xi16>) -> tensor<1x3x4x4xi16>
-// CHECK-DAG:             %[[VAL_6:.*]] = tosa.cast %[[VAL_5]] : (tensor<1x3x4x4xi16>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             %[[VAL_7:.*]] = tosa.mul %[[VAL_6]], %[[VAL_2]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
-// CHECK-DAG:             return %[[VAL_7]] : tensor<1x3x4x4xf32>
+// CHECK-LABEL:    func.func @i12_case
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
+// CHECK-DAG:         [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:         [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<3.200000e+01> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK:             [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_3_:%.+]] = tosa.cast [[VAR_2_]] : (tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xi12>
+// CHECK:             [[VAR_4_:%.+]] = tosa.cast [[VAR_3_]] : (tensor<1x3x4x4xi12>) -> tensor<1x3x4x4xf32>
+// CHECK:             [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x3x4x4xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x4x4xf32>
+// CHECK:             return [[VAR_5_]] : tensor<1x3x4x4xf32>
+// CHECK:           }
     func.func @i12_case(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32> {
         %0 = xten_nn.quantize(%arg0 : tensor<1x3x4x4xf32>) {scale = 3.125000e-02 : f32, shift = -5 : si32, zero_point = 0 : i12} -> tensor<1x3x4x4xi12>
         %1 = xten_nn.dequantize(%0 : tensor<1x3x4x4xi12>) {scale = 3.125000e-02 : f32, shift = -5 : si32, zero_point = 0 : i12} -> tensor<1x3x4x4xf32>


### PR DESCRIPTION
Follow up to #151 and #155

Changes to #151:
Only insert casts + add if the zero point is not zero.
Remove not needed clamp, tosa.cast already clamps