### PR TITLE
Stop depending on test libraries

### DIFF
--- a/test/Dialect/XTenNN/folding.mlir
+++ b/test/Dialect/XTenNN/folding.mlir
@@ -1,6 +1,6 @@
 // (c) Copyright 2023 - 2024 Advanced Micro Devices, Inc. All Rights reserved.
 
-// RUN: aten-opt --test-constant-fold --cse --split-input-file %s -o - | FileCheck %s
+// RUN: aten-opt --canonicalize --split-input-file %s -o - | FileCheck %s
 
 func.func @simple_dqq_fold(%arg0: tensor<1x2x7x7xf32>) -> tensor<1x2x7x7xf32> {
   %1 = "xten_nn.quantize"(%arg0) {shift = -3: si32, scale = 0.125 : f32, zero_point = 0 : i8} : (tensor<1x2x7x7xf32>) -> tensor<1x2x7x7xi8>

--- a/tools/aten-opt/CMakeLists.txt
+++ b/tools/aten-opt/CMakeLists.txt
@@ -44,7 +44,6 @@ set(LIBS
   ${torch_libs}
   ${dialect_libs}
   ${conversion_libs}
-  MLIRTestTransforms
   MLIROptLib
 )
 

--- a/tools/aten-opt/aten-opt.cpp
+++ b/tools/aten-opt/aten-opt.cpp
@@ -11,23 +11,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
-#include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/ToolOutputFile.h"
-
 #include "xten/Conversion/Passes.h"
-#include "xten/Dialect/XTenNN/IR/XTenNN.h"
 #include "xten/Dialect/XTenNN/IR/XTenNNBase.h"
 #include "xten/Dialect/XTenNN/Transforms/Passes.h"
 #include "xten/Transform/Passes.h"
@@ -35,13 +25,8 @@
 using namespace llvm;
 using namespace mlir;
 
-namespace mlir::test {
-void registerTestConstantFold();
-}
-
 int main(int argc, char **argv) {
   registerAllPasses();
-  mlir::test::registerTestConstantFold();
   xilinx::xten::registerTransformPasses();
   xilinx::xten::registerConversionPasses();
   amd::xten_nn::registerXTenNNPasses();


### PR DESCRIPTION
Allows to build without LLVM_INCLUDE_TESTS