### PR TITLE
Allow a method to be specified for LoadExternalConstOp

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -133,7 +133,7 @@ def XTenNN_QuantizeOp: XTenNN_Op<"quantize", [
   let arguments = (ins
     XTenNN_AnyFloatTensor:$input,
     OptionalAttr<SI32Attr>:$shift,
-    F32Attr:$scale, // Restricted to F32 for now, but may be relaxed in the future 
+    F32Attr:$scale, // Restricted to F32 for now, but may be relaxed in the future
     XTenNN_AnyIntegerAttr:$zero_point
   );
 
@@ -231,7 +231,7 @@ def XTenNN_GroupDequantizeOp: XTenNN_Op<"group_dequantize", [
   let summary = "Group dequantizes an integer tensor of given width to a float32 tensor.";
   let description = [{
     Dequantizes an integer tensor of given width to a float32 tensor.
-    
+
     Scales and zeros must have a shape that is broadcastable to the quants shape.
     Output and scales most have the same dtype, as must zeros and quants.
     The range of values in zeros and quants is given by the min and max attributes,
@@ -259,9 +259,11 @@ def XTenNN_GroupDequantizeOp: XTenNN_Op<"group_dequantize", [
 
 def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
             Pure]> {
-  let summary = "Loads a constant from an external h5 file to a const operator.";
+  let summary = "Loads a constant from an external source as a const operator.";
   let description = [{
-    Looks into `file` for `key`, retrieves the value and replace this operator by the loaded value.
+    Represents a constant value that can be provided by a `method`, but the values are not otherwise available.
+    The `method` is compiler-known and implemented, and not defined by this operation.
+    The default conceptual `method` is "h5", indicating that the value is stored in an h5 `file` at index `key`.
 
     Unfortunately, this operation cannot carry the ConstantLike trait as a Fold operation
     is required to be implemented for constants. For this particular operation we cannot return
@@ -272,10 +274,20 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
   }];
   let arguments = (ins
     StrAttr:$key,
-    StrAttr:$file
+    StrAttr:$file,
+    OptionalAttr<StrAttr>:$method
   );
 
   let results = (outs AnyTensor:$output);
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$output, "::mlir::StringAttr":$key,
+                   "::mlir::StringAttr":$file, "::mlir::StringAttr":$method)>,
+    OpBuilder<(ins "::mlir::Type":$output, "::mlir::StringAttr":$key,
+                   "::mlir::StringAttr":$file)>,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::llvm::StringRef":$key,
+                   "::llvm::StringRef":$file)>
+  ];
 
   let assemblyFormat = [{ attr-dict `->` type($output) }];
 }
@@ -305,7 +317,7 @@ def XTenNN_KernelOp : XTenNN_Op<"kernel", []> {
         "::mlir::TypeRange":$results,
         "::mlir::ValueRange":$arguments,
         "::llvm::StringRef":$name), [{
-          build($_builder, $_state, results, arguments, name, 
+          build($_builder, $_state, results, arguments, name,
             ::mlir::ArrayAttr(), ::mlir::ArrayAttr());
         }]
       >
@@ -601,7 +613,7 @@ def XtenNN_ConvTransposeOp: XTenNN_Op<"ConvTranspose",[Pure, TosaExtension]> {
 }
 
 def XtenNN_ReduceMeanOp: XTenNN_Op<"reduce_mean", [
-                                    Pure, TosaExtension, 
+                                    Pure, TosaExtension,
                                     InferTensorTypeAdaptor]> {
   let summary = "Reduce Mean operation";
   let description = [{
@@ -618,7 +630,7 @@ def XtenNN_ReduceMeanOp: XTenNN_Op<"reduce_mean", [
   let results = (outs
     AnyRankedTensor:$output
   );
-  
+
   let assemblyFormat = [{ operands attr-dict `:` functional-type(operands, results) }];
 }
 

--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -281,10 +281,6 @@ def XTenNN_LoadExternalConstOp: XTenNN_Op<"load_external_const", [
   let results = (outs AnyTensor:$output);
 
   let builders = [
-    OpBuilder<(ins "::mlir::Type":$output, "::mlir::StringAttr":$key,
-                   "::mlir::StringAttr":$file, "::mlir::StringAttr":$method)>,
-    OpBuilder<(ins "::mlir::Type":$output, "::mlir::StringAttr":$key,
-                   "::mlir::StringAttr":$file)>,
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::llvm::StringRef":$key,
                    "::llvm::StringRef":$file)>
   ];

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -1079,5 +1079,5 @@ void LoadExternalConstOp::build(mlir::OpBuilder &odsBuilder,
   // Use the auto-generated builder that takes TypeRange, StringAttr,
   // StringAttr, optional StringAttr
   LoadExternalConstOp::build(odsBuilder, odsState, resultTypes, keyAttr,
-                             fileAttr, /*method=*/nullptr);
+                             fileAttr, /*method=*/StringAttr{});
 }

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -385,7 +385,9 @@ ParseResult SubgraphOp::parse(OpAsmParser &p, OperationState &result) {
   return parseEnclaveOp(p, result);
 }
 
-void SubgraphOp::print(OpAsmPrinter &p) { printEnclaveOp(p, *this); }
+void SubgraphOp::print(OpAsmPrinter &p) {
+  printEnclaveOp(p, *this);
+}
 
 LogicalResult SubgraphOp::verify() {
   Block *optBody = this->getOptionalEnclaveBody();
@@ -1060,4 +1062,22 @@ LogicalResult ReduceMeanOp::inferReturnTypeComponents(
   inferredReturnShapes.push_back(
       ShapedTypeComponents(outputShape, inTy.getElementType()));
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LoadExternalConstOp
+//===----------------------------------------------------------------------===//
+
+void LoadExternalConstOp::build(mlir::OpBuilder &odsBuilder,
+                                mlir::OperationState &odsState,
+                                mlir::TypeRange resultTypes,
+                                llvm::StringRef key, llvm::StringRef file) {
+  assert(resultTypes.size() == 1 &&
+         "LoadExternalConstOp must have exactly one result");
+  auto keyAttr = StringAttr::get(odsBuilder.getContext(), key);
+  auto fileAttr = StringAttr::get(odsBuilder.getContext(), file);
+  // Use the auto-generated builder that takes TypeRange, StringAttr,
+  // StringAttr, optional StringAttr
+  LoadExternalConstOp::build(odsBuilder, odsState, resultTypes, keyAttr,
+                             fileAttr, /*method=*/nullptr);
 }

--- a/test/Dialect/XTenNN/loadExternalConst.mlir
+++ b/test/Dialect/XTenNN/loadExternalConst.mlir
@@ -1,23 +1,35 @@
-// (c) Copyright 2023 - 2024 Advanced Micro Devices, Inc. All Rights reserved.
+// (c) Copyright 2025 Advanced Micro Devices, Inc. All Rights reserved.
 
-// RUN: aten-opt %s -split-input-file -verify-diagnostics
+// RUN: aten-opt %s -split-input-file | FileCheck %s
 
-func.func @valid_LEC_op() -> tensor<1x2xf32> {
-    %result = xten_nn.load_external_const { key = "myLayerName", file = "weights.data"} -> tensor<1x2xf32>
-    return %result : tensor<1x2xf32>
+// Test backward compatibility (existing usage without method attribute)
+// CHECK-LABEL: @test_load_external_const_original
+func.func @test_load_external_const_original() -> tensor<4xf32> {
+  // CHECK: xten_nn.load_external_const {file = "weights.h5", key = "layer1.weight"} -> tensor<4xf32>
+  %0 = xten_nn.load_external_const {file = "weights.h5", key = "layer1.weight"} -> tensor<4xf32>
+  return %0 : tensor<4xf32>
 }
 
-// -----
-
-func.func @valid_LEC_op_bf16() -> tensor<1x2xbf16> {
-    %result = xten_nn.load_external_const { key = "myLayerName", file = "weights.data"} -> tensor<1x2xbf16>
-    return %result : tensor<1x2xbf16>
+// Test new method attribute
+// CHECK-LABEL: @test_load_external_const_with_method
+func.func @test_load_external_const_with_method() -> tensor<4xf32> {
+  // CHECK: xten_nn.load_external_const {file = "weights.h5", key = "layer1.weight", method = "hdf5"} -> tensor<4xf32>
+  %0 = xten_nn.load_external_const {file = "weights.h5", key = "layer1.weight", method = "hdf5"} -> tensor<4xf32>
+  return %0 : tensor<4xf32>
 }
 
-// -----
+// Test with different method values
+// CHECK-LABEL: @test_load_external_const_different_method
+func.func @test_load_external_const_different_method() -> tensor<2x3xi32> {
+  // CHECK: xten_nn.load_external_const {file = "data.bin", key = "conv.bias", method = "binary"} -> tensor<2x3xi32>
+  %0 = xten_nn.load_external_const {file = "data.bin", key = "conv.bias", method = "binary"} -> tensor<2x3xi32>
+  return %0 : tensor<2x3xi32>
+}
 
-func.func @invalid_key(%arg0: tensor<1x2xsi8>) -> tensor<1x2xf32> {
-    // expected-error@+1 {{'xten_nn.load_external_const' op attribute 'key' failed to satisfy constraint: string attribute}}
-    %result = xten_nn.load_external_const { key = 12.0 : f32, file = "weights.data"} -> tensor<1x2xf32>
-    return %result : tensor<1x2xf32>
+// Test with complex tensor types
+// CHECK-LABEL: @test_load_external_const_complex_type
+func.func @test_load_external_const_complex_type() -> tensor<1x256x512xbf16> {
+  // CHECK: xten_nn.load_external_const {file = "model.weights", key = "transformer.embeddings", method = "safetensors"} -> tensor<1x256x512xbf16>
+  %0 = xten_nn.load_external_const {file = "model.weights", key = "transformer.embeddings", method = "safetensors"} -> tensor<1x256x512xbf16>
+  return %0 : tensor<1x256x512xbf16>
 }

--- a/test/Dialect/XTenNN/loadExternalConst_diagnostics.mlir
+++ b/test/Dialect/XTenNN/loadExternalConst_diagnostics.mlir
@@ -1,0 +1,23 @@
+// (c) Copyright 2023 - 2024 Advanced Micro Devices, Inc. All Rights reserved.
+
+// RUN: aten-opt %s -split-input-file -verify-diagnostics
+
+func.func @valid_LEC_op() -> tensor<1x2xf32> {
+    %result = xten_nn.load_external_const { key = "myLayerName", file = "weights.data"} -> tensor<1x2xf32>
+    return %result : tensor<1x2xf32>
+}
+
+// -----
+
+func.func @valid_LEC_op_bf16() -> tensor<1x2xbf16> {
+    %result = xten_nn.load_external_const { key = "myLayerName", file = "weights.data"} -> tensor<1x2xbf16>
+    return %result : tensor<1x2xbf16>
+}
+
+// -----
+
+func.func @invalid_key(%arg0: tensor<1x2xsi8>) -> tensor<1x2xf32> {
+    // expected-error@+1 {{'xten_nn.load_external_const' op attribute 'key' failed to satisfy constraint: string attribute}}
+    %result = xten_nn.load_external_const { key = 12.0 : f32, file = "weights.data"} -> tensor<1x2xf32>
+    return %result : tensor<1x2xf32>
+}


### PR DESCRIPTION
We planned to use LoadExternalConstOp to support multiple compiler- known methods of accessing the constant values, but the method specifier was not added. This PR does so, keeping compatibility with existing uses of, effectively, a compiler-known default method.