### PR TITLE
Add motive attribute to DequantizeOp to prevent CSE

### DIFF
--- a/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
+++ b/include/xten/Dialect/XTenNN/IR/XTenNNOps.td
@@ -174,7 +174,8 @@ def XTenNN_DequantizeOp: XTenNN_Op<"dequantize", [
     XTenNN_AnySignlessOrUnsignedIntegerTensor:$input,
     OptionalAttr<SI32Attr>:$shift,
     F32Attr:$scale, // Restricted to F32 for now, but may be relaxed in the future
-    XTenNN_AnyIntegerAttr:$zero_point
+    XTenNN_AnyIntegerAttr:$zero_point,
+    OptionalAttr<StrAttr>:$motive
   );
 
   let results = (outs XTenNN_AnyFloatTensor:$output);

--- a/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
+++ b/lib/Dialect/XTenNN/IR/XTenNNOps.cpp
@@ -729,9 +729,11 @@ void DequantizeOp::build(mlir::OpBuilder &odsBuilder,
   const auto shiftValue = getShiftValue(scale.getValue().convertToFloat());
   if (zeroPointIsZero && shiftValue) {
     return build(odsBuilder, odsState, output, input,
-                 odsBuilder.getSI32IntegerAttr(*shiftValue), scale, zeroPoint);
+                 odsBuilder.getSI32IntegerAttr(*shiftValue), scale, zeroPoint,
+                 nullptr);
   }
-  return build(odsBuilder, odsState, output, input, nullptr, scale, zeroPoint);
+  return build(odsBuilder, odsState, output, input, nullptr, scale, zeroPoint,
+               nullptr);
 }
 
 void DequantizeOp::build(mlir::OpBuilder &odsBuilder,
@@ -743,7 +745,7 @@ void DequantizeOp::build(mlir::OpBuilder &odsBuilder,
   return build(odsBuilder, odsState, output, input,
                odsBuilder.getSI32IntegerAttr(shift),
                odsBuilder.getF32FloatAttr(*scale),
-               odsBuilder.getIntegerAttr(inputElemType, 0));
+               odsBuilder.getIntegerAttr(inputElemType, 0), nullptr);
 }
 
 LogicalResult DequantizeOp::verify() {


### PR DESCRIPTION
add an optional string attribute `motive` to `XTenNN.DequantizeOp` to support preventing CSE from merging identical dequantize operations that should remain distinct.